### PR TITLE
fix(AUTH): forcer le refresh du Token au lancement de l'app #1230

### DIFF
--- a/packages/backend/src/database/services/app-user/user-security/userSecurityEventHistoryManager.service.ts
+++ b/packages/backend/src/database/services/app-user/user-security/userSecurityEventHistoryManager.service.ts
@@ -20,7 +20,6 @@ function updateEventHistory({
   eventsHistory: AppUserSecurityEvent[];
   clearAllEvents?: boolean;
 }): AppUserSecurityEvent[] {
-  console.log("xxx clearAllEvents:", clearAllEvents);
   const event: AppUserSecurityEvent = {
     type: eventType,
     date: new Date(),

--- a/packages/backend/src/users/services/users-creator.service.spec.ts
+++ b/packages/backend/src/users/services/users-creator.service.spec.ts
@@ -82,10 +82,6 @@ describe("UsersCreator", () => {
     expect(user.structureId).toEqual(structureId);
     expect(userSecurity.userId).toEqual(user.id);
     expect(userSecurity.temporaryTokens).toBeDefined();
-    console.log(
-      "xxx (userSecurity.temporaryTokens",
-      JSON.stringify(userSecurity.temporaryTokens, undefined, 2)
-    );
     expect(userSecurity.temporaryTokens.type).toEqual("create-user");
     expect(userSecurity.temporaryTokens.token).toBeDefined();
     expect(userSecurity.temporaryTokens.validity).toBeDefined();

--- a/packages/frontend/src/app/modules/shared/services/auth.service.ts
+++ b/packages/frontend/src/app/modules/shared/services/auth.service.ts
@@ -76,6 +76,8 @@ export class AuthService {
         return true;
       }),
       catchError(() => {
+        this.currentUserSubject.next(null);
+        localStorage.removeItem("currentUser");
         return of(false);
       })
     );


### PR DESCRIPTION
@pYassine c'est déjà le comportement actuel constaté.

Dans `auth.service.ts` la méthode `isAuth` check le token et renvoie `false` si il est invalide.

J'ajoute juste un nettoyage du `currentUserSubject` à cet endroit.