### PR TITLE
fix(ci): dont include namespace on deploy

### DIFF
--- a/.k8s/kosko.toml
+++ b/.k8s/kosko.toml
@@ -1,4 +1,3 @@
-
 # dont default include jobs and namespace on deploys
 components = ["!_namespace", "!jobs", "*"]
 require = ["ts-node/register"]

--- a/.k8s/kosko.toml
+++ b/.k8s/kosko.toml
@@ -1,8 +1,4 @@
 
-# dont include jobs on deploys
-components = ["!jobs", "*"]
+# dont default include jobs and namespace on deploys
+components = ["!_namespace", "!jobs", "*"]
 require = ["ts-node/register"]
-
-# dont include underscores-prefix components
-[environments.prod]
-components = ["!_*"]


### PR DESCRIPTION
Ce change exclue par défaut le namespace dans les manifests k8s générés.