### PR TITLE
fix(export): l'export plante sur les grosses structures #1739

### DIFF
--- a/packages/backend/src/interactions/services/interactions.service.spec.ts
+++ b/packages/backend/src/interactions/services/interactions.service.spec.ts
@@ -31,4 +31,13 @@ describe("InteractionsService", () => {
   it("should be defined", () => {
     expect(interactionsService).toBeDefined();
   });
+
+  it("should return results", async () => {
+    // NOTE: on ne peut pas vérifier précisément les données de ce test tant qu'on isole pas les données de chaque test
+    const results =
+      await interactionsService.totalInteractionAllUsagersStructure({
+        structureId: 1,
+      });
+    expect(results).toBeDefined();
+  });
 });

--- a/packages/backend/src/interactions/services/interactions.service.ts
+++ b/packages/backend/src/interactions/services/interactions.service.ts
@@ -39,6 +39,53 @@ export class InteractionsService {
     return interactionRepository.findOne(where as any);
   }
 
+  public async totalInteractionAllUsagersStructure({
+    structureId,
+  }: {
+    structureId: number;
+  }): Promise<
+    {
+      usagerRef: number;
+      appel: number;
+      visite: number;
+      courrierIn: number;
+      courrierOut: number;
+      recommandeIn: number;
+      recommandeOut: number;
+      colisIn: number;
+      colisOut: number;
+    }[]
+  > {
+    // NOTE: cette requête ne renvoit pas de résultats pour les usagers de cette structure qui n'ont pas d'interaction
+    const query = `SELECT
+        i."usagerRef",
+        coalesce (COUNT(CASE WHEN i.type = 'appel' THEN 1 END), 0) AS "appel",
+        coalesce (COUNT(CASE WHEN i.type = 'visite' THEN 1 END), 0) AS "visite",
+        coalesce (SUM(CASE WHEN i.type = 'courrierIn' THEN "nbCourrier" END), 0) AS "courrierIn",
+        coalesce (SUM(CASE WHEN i.type = 'courrierOut' THEN "nbCourrier" END), 0) AS "courrierOut",
+        coalesce (SUM(CASE WHEN i.type = 'recommandeIn' THEN "nbCourrier" END), 0) AS "recommandeIn",
+        coalesce (SUM(CASE WHEN i.type = 'recommandeOut' THEN "nbCourrier" END), 0) AS "recommandeOut",
+        coalesce (SUM(CASE WHEN i.type = 'colisIn' THEN "nbCourrier" END), 0) AS "colisIn",
+        coalesce (SUM(CASE WHEN i.type = 'colisOut' THEN "nbCourrier" END), 0) AS "colisOut"
+      FROM interactions i
+      WHERE i."structureId" = $1 and i.event = 'create'
+      GROUP BY i."usagerRef"`;
+    const results = await (
+      await interactionRepository.typeorm()
+    ).query(query, [structureId]);
+    return results.map((x) => ({
+      usagerRef: x.usagerRef,
+      courrierIn: parseInt(x.courrierIn, 10),
+      courrierOut: parseInt(x.courrierOut, 10),
+      recommandeIn: parseInt(x.recommandeIn, 10),
+      recommandeOut: parseInt(x.recommandeOut, 10),
+      colisIn: parseInt(x.colisIn, 10),
+      colisOut: parseInt(x.colisOut, 10),
+      appel: parseInt(x.appel, 10),
+      visite: parseInt(x.visite, 10),
+    }));
+  }
+
   public async totalInteraction(
     structureId: number,
     usagerRef: number,


### PR DESCRIPTION
Optimisation en remplaçant 8 requêtes SQL par usager (soit 40 000 si 5000 usagers) par 1 seule.