### PR TITLE
chore(workflows): Use github actions cache

### DIFF
--- a/.github/workflows/preproduction.yml
+++ b/.github/workflows/preproduction.yml
@@ -23,7 +23,7 @@ jobs:
         echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
     - name: Use autodevops build and register
-      uses: SocialGouv/actions/autodevops-build-register@local-cache
+      uses: SocialGouv/actions/autodevops-build-register@v1
       with:
         project: ${{ env.project }}
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
         echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
     - name: Use autodevops build and register
-      uses: SocialGouv/actions/autodevops-build-register@local-cache
+      uses: SocialGouv/actions/autodevops-build-register@v1
       with:
         project: ${{ env.project }}
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
           echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
       - name: Use autodevops build and register
-        uses: SocialGouv/actions/autodevops-build-register@local-cache
+        uses: SocialGouv/actions/autodevops-build-register@v1
         with:
           project: ${{ env.project }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -24,7 +24,7 @@ jobs:
         echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
     - name: Use autodevops build and register
-      uses: SocialGouv/actions/autodevops-build-register@local-cache
+      uses: SocialGouv/actions/autodevops-build-register@v1
       with:
         project: ${{ env.project }}
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
         echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
     - name: Use autodevops build and register
-      uses: SocialGouv/actions/autodevops-build-register@local-cache
+      uses: SocialGouv/actions/autodevops-build-register@v1
       with:
         project: ${{ env.project }}
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -65,7 +65,7 @@ jobs:
           echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
       - name: Use autodevops build and register
-        uses: SocialGouv/actions/autodevops-build-register@local-cache
+        uses: SocialGouv/actions/autodevops-build-register@v1
         with:
           project: ${{ env.project }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -24,7 +24,7 @@ jobs:
           echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
       - name: Use autodevops build and register
-        uses: SocialGouv/actions/autodevops-build-register@local-cache
+        uses: SocialGouv/actions/autodevops-build-register@v1
         with:
           project: ${{ env.project }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
           echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
       - name: Use autodevops build and register
-        uses: SocialGouv/actions/autodevops-build-register@local-cache
+        uses: SocialGouv/actions/autodevops-build-register@v1
         with:
           project: ${{ env.project }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
           echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
       - name: Use autodevops build and register
-        uses: SocialGouv/actions/autodevops-build-register@local-cache
+        uses: SocialGouv/actions/autodevops-build-register@v1
         with:
           project: ${{ env.project }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -5,9 +5,10 @@ ENV TZ Europe/Paris
 RUN cp /usr/share/zoneinfo/Europe/Paris /etc/localtime
 RUN apt-get update && apt-get install -y pdftk
 
-COPY ./packages/backend /app
-
 WORKDIR /app
+
+COPY ./packages/backend .
+COPY ./yarn.lock .
 
 # TODO: Sort dependencies and add "--production" install flag
 RUN yarn --frozen-lockfile && yarn cache clean

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:16.12.0 as builder
 
-COPY ./packages/frontend /app
-
 WORKDIR /app
+
+COPY ./packages/frontend .
+COPY ./yarn.lock .
 
 # TODO: Sort dependencies and add "--production" install flag
 RUN yarn --frozen-lockfile && yarn cache clean

--- a/packages/portail-usagers/Dockerfile
+++ b/packages/portail-usagers/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:16.12.0 as builder
 
-COPY ./packages/portail-usagers /app
-
 WORKDIR /app
+
+COPY ./packages/portail-usagers .
+COPY ./yarn.lock .
 
 RUN yarn --frozen-lockfile && yarn cache clean
 RUN yarn build


### PR DESCRIPTION
- Restore Github image build cache to speed up workflow build steps.
- Copy `yarn.lock` file to docker images before `yarn install`.