### PR TITLE
fix(doc): add preset doc to readme

### DIFF
--- a/_docs/dev/00.run-local-env.md
+++ b/_docs/dev/00.run-local-env.md
@@ -22,10 +22,21 @@ En mode `full-docker`, le fichier `packages/backend/.env` doit contenir:
 POSTGRES_HOST=postgres
 ```
 
+Ou utiliser le preset docker :
+
+```env
+DOMIFA_ENV_PRESET=local-dev-docker.preset.env
+```
+
 Sinon:
 
 ```env
 POSTGRES_HOST=localhost
+```
+Ou utiliser le preset localhost :
+
+```env
+DOMIFA_ENV_PRESET=local-dev.preset.env
 ```
 
 ## Lancement de l'environnement (docker)


### PR DESCRIPTION
Hello,
en lisant la doc d'install j'ai constaté qu'on disait d'utiliser POSTGRES_HOST mais j'ai bien l'impression que maintenant on peut aussi utiliser le preset associé.
Je me demande d'ailleurs si ducoup il faudrait pas retirer ces variables du .env pour toujours utiliser le preset car actuellement ça fait un peu doublon donc on sait pas trop laquelle est vraiment utilisée ?
