### PR TITLE
fix(docker): switch to base postgres image

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -5,7 +5,7 @@ volumes:
 
 services:
   postgres:
-    image: postgresai/extended-postgres:14
+    image: postgres:14
     container_name: domifa-postgres
     volumes:
       - postgres-data:/var/lib/postgresql/data


### PR DESCRIPTION
Hello,
en essayant l'install avec l'image extentended il semble pas lancer le script d'initdb correctement:
```
chown: cannot access '/var/lib/postgresql/data/pgdata': No such file or directory
postgres: could not access directory "/var/lib/postgresql/data/pgdata": No such file or directory
Run initdb or pg_basebackup to initialize a PostgreSQL data directory.
```

Ca marche bien avec l'image standard.
Je connais pas les raisons de l'utilisation de cette image alors je vous laisse voir si ce changement est possible