### PR TITLE
fix(env): fixing local preset name

### DIFF
--- a/packages/backend/.env.preset/local-dev.preset.env
+++ b/packages/backend/.env.preset/local-dev.preset.env
@@ -5,7 +5,7 @@
 # files config will overrides process.env
 DOMIFA_ENV_PRIORITY="files"
 
-DOMIFA_ENV_ID=dev
+DOMIFA_ENV_ID=local
 
 DOMIFA_FRONTEND_URL=http://localhost:4200/
 DOMIFA_PORTAIL_USAGERS_URL=http://localhost:4201/


### PR DESCRIPTION
J'ai constaté en lancant le back qu'il executait pas les migration avec la config par défaut ( il y a une condition !== "local" alors qu'il était sur "dev" dan le preset)
-> [MIGRATIONS] Disable in this pod
Je sais pas si c'est à cet endroit qu'il convient de le changer mais j'imagine qu'il faut que les migrations se lancent en local quand on lance le back pour la première fois ?