### PR TITLE
fix(sentry): prevent logging errors from /connexion

### DIFF
--- a/packages/frontend/src/app/app.module.ts
+++ b/packages/frontend/src/app/app.module.ts
@@ -44,6 +44,8 @@ if (environment.production) {
     dsn: "https://5dab749719e9488798341efad0947291@sentry.fabrique.social.gouv.fr/31",
     environment: environment.env,
     tracesSampleRate: 1.0,
+    // skip errors that produces lots of 401
+    denyUrls: ["/connexion"],
   });
 }
 


### PR DESCRIPTION
A priori +90% des erreurs sentry sont envoyées depuis la page `/connexion`. J'ai l'impression que quand les users se font déconnecter ils arrivent sur `/connexion` et tous les appels tombent en 401 puis dans sentry