### PR TITLE
fix(k8s): resources

### DIFF
--- a/.kube-workflow/prod/values.yaml
+++ b/.kube-workflow/prod/values.yaml
@@ -71,7 +71,7 @@ app-backend:
     - files
   resources:
     requests:
-      cpu: 1
+      cpu: 0.5
       memory: 512Mi
     limits:
       cpu: 2
@@ -114,30 +114,30 @@ app-frontend:
   certSecretName: frontend-crt
   resources:
     requests:
-      cpu: 0.2
-      memory: 256Mi
+      cpu: 0.1
+      memory: 64Mi
     limits:
-      cpu: 1
-      memory: 1Gi
+      cpu: 0.5
+      memory: 512Mi
 
 app-portail-admins:
   host: "admin-domifa.fabrique.social.gouv.fr"
   certSecretName: portail-admins-crt
   resources:
     requests:
-      cpu: 0.2
-      memory: 256Mi
+      cpu: 0.1
+      memory: 64Mi
     limits:
-      cpu: 1
-      memory: 1Gi
+      cpu: 0.5
+      memory: 512Mi
 
 app-portail-usagers:
   host: "mon-domifa.fabrique.social.gouv.fr"
   certSecretName: portail-usagers-crt
   resources:
     requests:
-      cpu: 0.2
-      memory: 256Mi
+      cpu: 0.1
+      memory: 64Mi
     limits:
-      cpu: 1
-      memory: 1Gi
+      cpu: 0.5
+      memory: 512Mi

--- a/.kube-workflow/prod/values.yaml
+++ b/.kube-workflow/prod/values.yaml
@@ -23,10 +23,10 @@ app-backend-cron:
   certSecretName: backend-crt
   resources:
     requests:
-      cpu: 0.2
+      cpu: 0.1
       memory: 256Mi
     limits:
-      cpu: 1.5
+      cpu: 1
       memory: 2Gi
   addVolumes:
     - files

--- a/.kube-workflow/prod/values.yaml
+++ b/.kube-workflow/prod/values.yaml
@@ -26,7 +26,7 @@ app-backend-cron:
       cpu: 0.1
       memory: 256Mi
     limits:
-      cpu: 1
+      cpu: 2
       memory: 2Gi
   addVolumes:
     - files
@@ -75,7 +75,7 @@ app-backend:
       memory: 512Mi
     limits:
       cpu: 2
-      memory: 2Gi
+      memory: 4Gi
   envFrom:
     - secretRef:
         name: "{{ .Values.global.pgSecretName }}"

--- a/.kube-workflow/values.yaml
+++ b/.kube-workflow/values.yaml
@@ -2,6 +2,13 @@ app-frontend:
   imagePackage: frontend
   host: "{{ .Values.global.host }}"
   containerPort: 8080
+  resources:
+    requests:
+      cpu: 0.05
+      memory: 64Mi
+    limits:
+      cpu: 0.5
+      memory: 512Mi
 
 app-backend: # todo: probes
   imagePackage: backend
@@ -37,6 +44,13 @@ app-backend: # todo: probes
       value: "https://admin-{{ .Values.global.host }}/"
     - name: DOMIFA_CRON_ENABLED
       value: "false"
+  resources:
+    requests:
+      cpu: 0.1
+      memory: 128Mi
+    limits:
+      cpu: 1.5
+      memory: 2Gi
 
 app-backend-cron:
   imagePackage: backend
@@ -74,16 +88,37 @@ app-backend-cron:
       value: "true"
     - name: ELASTIC_APM_SERVICE_NAME
       value: "$(CRON_ELASTIC_APM_SERVICE_NAME)" # override using kubernetes interpolation from configmap var
+  resources:
+    requests:
+      cpu: 0.1
+      memory: 128Mi
+    limits:
+      cpu: 1.5
+      memory: 2Gi
 
 app-portail-usagers:
   imagePackage: portail-usagers
   containerPort: 8080
   host: "mon-{{ .Values.global.host }}"
+  resources:
+    requests:
+      cpu: 0.05
+      memory: 64Mi
+    limits:
+      cpu: 0.5
+      memory: 512Mi
 
 app-portail-admins:
   imagePackage: portail-admins
   containerPort: 8080
   host: "admin-{{ .Values.global.host }}"
+  resources:
+    requests:
+      cpu: 0.05
+      memory: 64Mi
+    limits:
+      cpu: 0.5
+      memory: 512Mi
 
 metabase:
   enabled: false


### PR DESCRIPTION
Ajustement ressources

(En dev on request le minimum pour ne pas surcharger le cluster dev)

## dev

composant | cpu request | cpu limit | memory request | memory limit
------------|-------------|----------|-----------------|---------------
backend | 0.1 | 1.5 | 128Mi | 2Gi
backend-cron | 0.1 | 1.5 | 128Mi | 2Gi
frontend | 0.05 | 0.5 | 64Mi | 512Mi
portails-admins | 0.05 | 0.5 | 64Mi | 512Mi
portails-usagers | 0.05 | 0.5 | 64Mi | 512Mi

## prod

composant | cpu request | cpu limit | memory request | memory limit
------------|-------------|----------|-----------------|---------------
backend | 0.5 | 2 | 512Mi | 4Gi
backend-cron | 0.1 | 2 | 256Mi | 2Gi
frontend | 0.1 | 0.5 | 64Mi | 512Mi
portails-admins | 0.1 | 0.5 | 64Mi | 512Mi
portails-usagers | 0.1 | 0.5 | 64Mi | 512Mi

basé sur les [consos de prod](https://grafana.fabrique.social.gouv.fr/d/GnIeVD5Vz/kubernetes-compute-resources-namespace-pods?orgId=1&refresh=10s&var-datasource=Thanos%20-%20Prod&var-cluster=prod2&var-namespace=domifa&from=now-5d&to=now) : 

backend : 

<img width="1698" alt="Capture d’écran 2022-12-21 à 10 28 41" src="https://user-images.githubusercontent.com/124937/208871287-0d6839ae-f5d6-4f92-a4d1-206a7f4230f3.png">

frontend : 

<img width="1693" alt="Capture d’écran 2022-12-21 à 10 28 58" src="https://user-images.githubusercontent.com/124937/208871333-093b744f-6864-4ddb-ab9d-03693b31fc7b.png">

