### PR TITLE
feat: restore + anonymise

### DIFF
--- a/.kontinuous/jobs/preprod-restore/config.yaml
+++ b/.kontinuous/jobs/preprod-restore/config.yaml
@@ -1,0 +1,1 @@
+projectName: domifa

--- a/.kontinuous/jobs/preprod-restore/values.yaml
+++ b/.kontinuous/jobs/preprod-restore/values.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=../../../../kontinuous/docs/values.schema.json
+
+jobs:
+  runs:
+    restore:
+      ~needs: [pg]
+      image: ghcr.io/socialgouv/docker/s3-client:1.2.0
+      entrypoint: ["/bin/bash"]
+      args:
+        - "-c"
+        - "pg_restore"
+      envFrom:
+        - secretRef:
+            name: pg-superuser
+        - secretRef:
+            name: s3

--- a/.kontinuous/jobs/prod-dump/Chart.yaml
+++ b/.kontinuous/jobs/prod-dump/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: cnpg-cluster
+version: 1.0.0
+dependencies:
+  - name: cnpg-cluster
+    version: 1.18.2
+    repository: https://socialgouv.github.io/helm-charts

--- a/.kontinuous/jobs/prod-dump/config.yaml
+++ b/.kontinuous/jobs/prod-dump/config.yaml
@@ -1,0 +1,1 @@
+projectName: domifa

--- a/.kontinuous/jobs/prod-dump/templates/s3.sealed-secret.yaml
+++ b/.kontinuous/jobs/prod-dump/templates/s3.sealed-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    sealedsecrets.bitnami.com/namespace-wide: "true"
+  name: s3
+  namespace: domifa-restore
+spec:
+  encryptedData:
+    TOKEN: AgCbbXzeCN7+hq8tsncJq8M0VrZCR35n1aZSY0f+w45Oa9IHKYTB5E2xE8xlL7tppMRE7FF7Oqw/MmH6uFJJJ2iqF1h2GOCty/P0f5N+7NWnCQkenJnH8JY9GipPEd4RZ9+D06fBlVXT+IOAMred7BoN7bmnh90nOyh+qbeNF9+Szez5wWb4bA0HoFYblRIWiXQpOqpNuQncrKAUUd+eiL8fQCInMTtIDnemiOzceLJGNBwyCFBA3Y7gesgB0563GeK9l9HZzV9FDP/FLzxUG/n2Ir9Tz4q6UTDxU8CCI4VmEDpz3Chd5hSnWWFz/KlDLt302buL2NhBpfel9aSl8QJdF1io4hnww+IfbCZpW/U9bCdbP01MwVON7oByo+Ce5oiGKAYlm1r2pXFXyMJzjCJT5JSwl9Ld2dIuqU3pNePM6gTF/Yca+Z62NShzctqW+lbLEkLi/pGksVArR3nwHIBME22F+SxkYIfe5jUVfddnDN5C8BZWq8rCAd/M0vrNNb+iclTDGSeh3wfDH/f0hm5+xGID1XmMU/qaPFZYObPV8xX2BW6HYgY386Zq3ltzinM4ogI0xachw4+1Vp+N0HyLnfACoJ4YWjP9PCVka9fdX4fRdVX4IVsnnuMemwuAs8+815OoUdj3DBk1oLLJML+Eq/83ilRN50fUkN0cObc6AVix9BXHqBsAXwl7on9+lQ29qefY
+  template:
+    metadata:
+      annotations:
+        sealedsecrets.bitnami.com/namespace-wide: "true"
+      name: s3
+    type: Opaque

--- a/.kontinuous/jobs/prod-dump/values.yaml
+++ b/.kontinuous/jobs/prod-dump/values.yaml
@@ -1,0 +1,84 @@
+# yaml-language-server: $schema=../../../../kontinuous/docs/values.schema.json
+
+global:
+  namespace: domifa-prod-dump
+
+cnpg-cluster:
+  ~chart: cnpg-cluster
+  fullnameOverride: pg-restore
+  postgresqlParameters:
+    TimeZone: Europe/Paris
+  instances: 1
+  persistence:
+    size: 20Gi
+  backup:
+    enabled: false
+  recovery:
+    enabled: true
+    barmanObjectStore:
+      destinationPath: s3://domifa-prod-backups/domifa
+      endpointURL: https://s3.gra.io.cloud.ovh.net
+      serverName: pg
+      data:
+        compression: gzip
+      wal:
+        compression: gzip
+      s3Credentials:
+        accessKeyId:
+          key: bucket_access_key
+          name: domifa-prod-backups-access-key
+        region:
+          key: bucket_region
+          name: domifa-prod-backups-access-key
+        secretAccessKey:
+          key: bucket_secret_key
+          name: domifa-prod-backups-access-key
+
+prod-dump-jobs:
+  ~chart: jobs
+  runs:
+    anonymise:
+      ~needs: [cnpg-cluster]
+      image: ghcr.io/socialgouv/docker/s3-client:1.2.0
+      entrypoint: ["/bin/bash"]
+      args:
+        - "-c"
+        - "echo 42"
+      envFrom:
+        - secretRef:
+            name: pg-tmp-superuser
+    dump:
+      ~needs: [anonymise]
+      image: ghcr.io/socialgouv/docker/s3-client:1.2.0
+      env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: s3
+              key: bucket_access_key
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: s3
+              key: bucket_secret_key
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              name: s3
+              key: bucket_region
+        - name: AWS_ENDPOINT_URL
+          value: https://s3.gra.io.cloud.ovh.net
+        - name: DESTINATION_PATH
+          value: s3://domifa-tmp-restore/prod-anonymised-dump
+      envFrom:
+        - secretRef:
+            name: pg-tmp-superuser
+        - secretRef:
+            name: s3
+    destroy:
+      ~needs: [dump]
+      image: ghcr.io/socialgouv/docker/s3-client:1.2.0
+      entrypoint: ["/bin/bash"]
+      args:
+        - "-c"
+        - "echo 43"

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,4 +1,8 @@
 fileignoreconfig:
+- filename: .kontinuous/jobs/prod-dump/templates/s3.sealed-secret.yaml
+  checksum: 440af74556bc0d4f8df2817596587a249091b37a32f89cc0ea8170f123dd9262
+- filename: .kontinuous/jobs/prod-dump/values.yaml
+  checksum: db0f473b39accc19002eacc1055377100fe26d73d9908400f1110015f98aa53b
 - filename: _scripts/db/dumps/domifa_test.postgres.restore-data-only.sql
   checksum: 23f737871ba69871381febc4f867d82367187384b16250e79ce8729fddf53030
 - filename: _scripts/db/dumps/domifa_test.postgres.truncate-restore-data-only.sql


### PR DESCRIPTION
restore and anonymify from prod to some development DB

 - [x] Prod job : pop a CNPG-tmp cluster from Prod WALs
 - [x] Prod job : run anonymize the new PG instance
 - [x] Prod job : dump to s3-tmp
 - [ ] Prod job : destroy CNPG-tmp
 - [ ] Trigger Preprod job: download and restore to Preprod CNPG from s3-tmp

Notes :
 - the prod jobs run in a dedicated `domifa-prod-dump` namespace to prevent interference with prod
 - il y a probablement un cleanup de [l'image docker/s3-client](https://github.com/SocialGouv/docker/tree/master/s3-client) pour permettre aussi le download+restore ?
 - a priori il faudrait utiliser [cette approche pour trigger les jobs](https://socialgouv.github.io/kontinuous/#/./faq?id=trigger-specific-jobs-or-deployments)

```mermaid
graph TD

GH[workflow dispatch update preprod data]-->DeployProd[kontinuous deploy prod job]
DeployProd-->CNPG1[Create tmp CNPG cluster from prod WALs]-->AnonymiseJob[anonymise]-->DumpJob[Dump]-->Store-->S3{S3}
GH2[Trigger Gh workflow preprod update]-->DeployPreProd[kontinuous deploy preprod job]
DeployPreProd-->DownloadJob-->RestoreJob
Store-->Destroy
Store-->GH2
DownloadJob-->S3[S3-tmp]
subgraph Prod
CNPG1
AnonymiseJob
DumpJob
Store
Destroy
end
subgraph PreProd
CNPG1
DownloadJob
RestoreJob
end
subgraph GitHub
GH
GH2
DeployProd
DeployPreProd
end
```
