### PR TITLE
Fix : Update politique.component.html

### DIFF
--- a/packages/portail-admins/src/app/modules/general/components/static-pages/politique/politique.component.html
+++ b/packages/portail-admins/src/app/modules/general/components/static-pages/politique/politique.component.html
@@ -172,18 +172,6 @@
                 </a>
               </td>
             </tr>
-            <tr>
-              <td>Matomo</td>
-              <td>Analyses statistiques</td>
-              <td>Mesure d'audience</td>
-              <td>
-                <a
-                  href="https://fr.matomo.org/matomo-cloud-dpa/
-"
-                  >https://fr.matomo.org/matomo-cloud-dpa/
-                </a>
-              </td>
-            </tr>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
Suppression du sous-traitant Matomo dont l'utilisation est uniquement sur la base de données anonymisées donc il n'y a pas besoin de le mentionner dans la politique de confidentialité.