### PR TITLE
Fix: 🐞 Bug (GESTION DE MASSE) - Problème de sélection multiples de dossiers pour réaliser une action de masse lorsque l'on scrolle sur la liste

### DIFF
--- a/packages/frontend/src/app/modules/manage-usagers/components/manage-usagers-table/manage-usagers-table.component.ts
+++ b/packages/frontend/src/app/modules/manage-usagers/components/manage-usagers-table/manage-usagers-table.component.ts
@@ -103,15 +103,12 @@ export class ManageUsagersTableComponent implements OnInit, OnDestroy {
   ) {
     this.me = this.authService.currentUserValue;
     this.usagers = [];
-    this.selectedRefs.clear();
   }
 
   ngOnInit() {
     this.filters$.pipe(takeUntil(this.destroy$)).subscribe((filters) => {
       this.currentFilters = filters;
       this.computeCheckboxVisibility();
-      this.selectAllCheckboxes = false;
-      this.selectedRefs.clear();
       this.cd.markForCheck();
     });
   }
@@ -176,6 +173,9 @@ export class ManageUsagersTableComponent implements OnInit, OnDestroy {
   }
 
   public getVisibleCheckboxIds(): void {
+    if (!this.selectAllCheckboxes) {
+      return;
+    }
     const checkboxes = document.querySelectorAll(
       'table input[type="checkbox"]'
     );
@@ -199,15 +199,11 @@ export class ManageUsagersTableComponent implements OnInit, OnDestroy {
       }
     });
 
-    if (!this.selectAllCheckboxes) {
-      this.selectedRefs.clear();
-    } else {
-      visibleIds.forEach((id) => {
-        if (!this.selectedRefs.has(id)) {
-          this.selectedRefs.add(id);
-        }
-      });
-    }
+    visibleIds.forEach((id) => {
+      if (!this.selectedRefs.has(id)) {
+        this.selectedRefs.add(id);
+      }
+    });
   }
 
   public resetCheckboxes() {


### PR DESCRIPTION
Fixed by GitFix AI Agent.

The issue was caused by two main factors in the ManageUsagersTableComponent. First, in ngOnInit, the subscription to filters$ was aggressively resetting selectAllCheckboxes and clearing selectedRefs every time the filter observable emitted. In an infinite scroll context, scrolling to load more results often triggers a filter emission (even if criteria remain the same), causing the selection to be lost. Second, the getVisibleCheckboxIds method, which is likely called during scroll events to handle 'Select All' functionality, contained logic that cleared the selection whenever selectAllCheckboxes was false. This meant any manual selections were wiped as soon as the user scrolled. The fix removes the automatic clearing in ngOnInit (deferring that responsibility to the parent component or specific filter change events) and adds an early return in getVisibleCheckboxIds to prevent clearing selectedRefs when not in 'Select All' mode.

Test: 1. Go to the usagers management list. 2. Manually select a few usagers by checking their checkboxes. 3. Scroll down the list to trigger the loading of the next page/set of results. 4. Verify that the previously checked boxes remain checked. 5. Enable the 'Select All' checkbox in the header. 6. Scroll down further and verify that newly loaded visible items are also automatically added to the selection. 7. Verify that changing a 'real' filter (like searching for a name or changing status) still correctly clears the selection (this should be handled by the parent component's filter update logic).