### PR TITLE
Update admin-structures-list.component.ts

### DIFF
--- a/packages/portail-admins/src/app/modules/admin-structures/components/admin-structures-list/admin-structures-list.component.ts
+++ b/packages/portail-admins/src/app/modules/admin-structures/components/admin-structures-list/admin-structures-list.component.ts
@@ -235,7 +235,7 @@ export class AdminStructuresListComponent
   public get statutTabs(): FilterTab[] {
     return [
       { key: "", label: "Toutes", count: this.totalStructures },
-      { key: "VALIDE", label: "Actives", count: this.statusCounts.VALIDE },
+      { key: "VALIDE", label: "Validées", count: this.statusCounts.VALIDE },
       {
         key: "EN_ATTENTE",
         label: "Non validées",


### PR DESCRIPTION
Précision sur le label qui n'est pas adapté : les structures actives ne figurent pas forcément dans cette catégorie. Remplacement du terme Actives par Validées qui est plus adapté et permet d'être cohérent par rapport au statut "non validées"