### PR TITLE
fix(backend): strip psql meta-commands from the review env dumps

### DIFF
--- a/_scripts/db/dumps/domifa_test.postgres.restore-data-only.sql
+++ b/_scripts/db/dumps/domifa_test.postgres.restore-data-only.sql
@@ -2,7 +2,6 @@
 -- PostgreSQL database dump
 --
 
-\restrict oP3k7sbLlJfjdqZQHiDBykToMPNHGTcfmo7OvgyIva0MYOaXaSkiXNFKZ7nB5nC
 
 -- Dumped from database version 16.14
 -- Dumped by pg_dump version 16.14
@@ -728,5 +727,4 @@ SELECT pg_catalog.setval('public.user_usager_id_seq', 2, true);
 -- PostgreSQL database dump complete
 --
 
-\unrestrict oP3k7sbLlJfjdqZQHiDBykToMPNHGTcfmo7OvgyIva0MYOaXaSkiXNFKZ7nB5nC
 

--- a/_scripts/db/dumps/domifa_test.postgres.truncate-restore-data-only.sql
+++ b/_scripts/db/dumps/domifa_test.postgres.truncate-restore-data-only.sql
@@ -40,7 +40,6 @@
 -- PostgreSQL database dump
 --
 
-\restrict oP3k7sbLlJfjdqZQHiDBykToMPNHGTcfmo7OvgyIva0MYOaXaSkiXNFKZ7nB5nC
 
 -- Dumped from database version 16.14
 -- Dumped by pg_dump version 16.14
@@ -766,5 +765,4 @@ SELECT pg_catalog.setval('public.user_usager_id_seq', 2, true);
 -- PostgreSQL database dump complete
 --
 
-\unrestrict oP3k7sbLlJfjdqZQHiDBykToMPNHGTcfmo7OvgyIva0MYOaXaSkiXNFKZ7nB5nC
 

--- a/packages/backend/src/_migrations/_init-db/domifa_test_schema.sql
+++ b/packages/backend/src/_migrations/_init-db/domifa_test_schema.sql
@@ -1,4 +1,6 @@
-\restrict tQ6c6weVjeOkHoi0DKfDLRiNBVIehe5eCjWkLD90nfyR45X4mDrKsvox86IM8SU
+-- Replayed by CreateDatabase1603812391580 through the TypeORM driver, not psql.
+-- Keep this file free of psql meta-commands (\restrict, \unrestrict, \connect...):
+-- pg_dump emits them since 17.6/16.10, and the server rejects them as syntax errors.
 CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA public;
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
 CREATE TABLE public.app_ip_ban (
@@ -816,4 +818,3 @@ ALTER TABLE ONLY public.usager_notes
     ADD CONSTRAINT "FK_e8b75cd4ebe81d288a6ff7d4115" FOREIGN KEY ("structureId") REFERENCES public.structure(id) ON DELETE CASCADE;
 ALTER TABLE ONLY public.interactions
     ADD CONSTRAINT "FK_f9c3ee379ce68d4acfe4199a335" FOREIGN KEY ("usagerUUID") REFERENCES public.usager(uuid) ON DELETE CASCADE;
-\unrestrict tQ6c6weVjeOkHoi0DKfDLRiNBVIehe5eCjWkLD90nfyR45X4mDrKsvox86IM8SU


### PR DESCRIPTION
## Problème

Le job `Deploy Review on Kubernetes` échoue sur **toutes** les branches de review depuis le 2026-05-19, quel que soit le contenu de la branche. Les builds passent, le déploiement meurt sur `backend-cron` :

```
Deployment "backend-cron" is not progressing: ReplicaSet ... has timed out progressing.
❌ failed: deployment-backend-cron-... [10m]
```

`backend-cron` crashloope parce que la migration d'init de base échoue :

```
Migration "createDatabaseMigration1603812391580" failed, error: syntax error at or near "\"
```

## Cause

`pg_dump` encadre sa sortie de `\restrict` / `\unrestrict` depuis les versions 17.6, 16.10, 15.14, 14.19 et 13.22 (durcissement CVE-2025-8714, publié le 14 août 2025). Ce sont des **méta-commandes psql**, pas du SQL.

Nos dumps ont été régénérés avec un `pg_dump` récent, et trois fichiers en ont hérité. Ils cassent de deux façons différentes :

| Fichier | Consommateur | Symptôme |
|---|---|---|
| `packages/backend/.../_init-db/domifa_test_schema.sql` | `queryRunner.query()` (driver TypeORM) | le serveur reçoit `\restrict` → `syntax error at or near "\"` |
| `_scripts/db/dumps/domifa_test.postgres.restore-data-only.sql` | `psql` (job `seed-db`) | client psql < 16.10 → `invalid command \restrict` |
| `_scripts/db/dumps/domifa_test.postgres.truncate-restore-data-only.sql` | idem | idem, et le `\set ON_ERROR_STOP true` du dump interrompt le job |

Les deux étapes sont en série dans le rollout : `backend-cron` d'abord, `seed-db` juste après. Corriger seulement la première fait échouer la seconde.

## Correction

Suppression des lignes `\restrict` / `\unrestrict` dans les trois fichiers, plus un commentaire en tête du dump de schéma pour éviter la récidive à la prochaine régénération.

Rien d'autre n'est touché : les 30 terminateurs `\.` de `COPY` et le `\set ON_ERROR_STOP true` sont conservés, ce sont eux dont psql a besoin.

## Vérification

Contre un PostgreSQL 16 + PostGIS réel, avec un client psql 16.9 — donc antérieur à 16.10, comme celui du job.

Schéma, via le driver `pg` exactement comme `queryRunner.query()` :

```
avant : ECHEC syntax error at or near "\"  position=1 routine=scanner_yyerror
après : OK, dump exécuté, 33 tables dans public
```

Seed, via psql comme le job :

```
avant : psql:...:43: error: invalid command \restrict
après : aucune erreur — usager=13 structure=5 user_structure=11
```

Les environnements déjà cassés se répareront seuls au prochain déploiement : l'échec du schéma ne laisse rien derrière lui (transaction implicite, aucun `BEGIN`/`COMMIT` dans le dump) et la migration, non enregistrée, est rejouée.

## Note

Ce correctif ne concerne que les environnements de review : la migration sort immédiatement quand `envId` vaut `prod` ou `preprod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)