### PR TITLE
fix(backend): run import parse/validation in a worker thread (root cause of the 11/08 outage)

### DIFF
--- a/packages/backend/src/usagers/controllers/import/import.controller.ts
+++ b/packages/backend/src/usagers/controllers/import/import.controller.ts
@@ -25,12 +25,11 @@ import {
 } from "../../../util/file-manager/FileManager";
 import { UserStructureAuthenticated } from "../../../_common/model";
 import { ImportProcessTracker } from "./ImportProcessTracker.type";
-import { UsagersImportError, UsagersImportRow } from "./model";
-import { usagersImportExcelParser } from "./step1-parse-excel";
+import { ImportParseAndValidateResult } from "./parseAndValidateImportFile";
 import {
-  UsagersImportUsager,
-  usagersImportValidator,
-} from "./step2-validate-row";
+  ImportRunnerError,
+  usagersImportRunner,
+} from "./usagersImportRunner.service";
 
 import {
   AllowUserProfiles,
@@ -42,8 +41,6 @@ import { remove } from "fs-extra";
 import { FILES_SIZE_LIMIT } from "../../../util/file-manager";
 import {
   ImportPreviewTable,
-  ImportPreviewRow,
-  ImportPreviewColumn,
   COUNTRY_CODES_TIMEZONE,
   UsagersImportMode,
   ImportDocumentType,
@@ -110,27 +107,6 @@ export class ImportController {
     const fileName = file.filename;
     const filePath = file.path;
 
-    let usagerImportRows: {
-      rowNumber: number;
-      row: UsagersImportRow;
-    }[] = [];
-
-    try {
-      usagerImportRows = await usagersImportExcelParser.parseFileSync(filePath);
-      processTracker.data = { count: usagerImportRows.length };
-    } catch (err) {
-      appLogger.error(`Import unexpected error while opening upload file`, {
-        sentry: true,
-        context: {
-          err,
-          fileName,
-        },
-      });
-      return res
-        .status(HttpStatus.BAD_REQUEST)
-        .json({ message: "EXCEL_FILE_CORRUPTED" });
-    }
-
     let previewTable: ImportPreviewTable;
     const today = endOfDay(new Date());
     const nextYear = addYears(endOfDay(new Date()), 1);
@@ -138,72 +114,53 @@ export class ImportController {
 
     const structureId = user.structureId;
     const importContext = { fileName, filePath, structureId };
-
-    let importErrors: UsagersImportError[] = [];
-    const importPreviewRows: ImportPreviewRow[] = [];
-
-    const usagersRows: UsagersImportUsager[] = [];
-    const previewUsagersRow: UsagersImportUsager[] = [];
     const maxErrors = 20;
+
+    // Parse + validation dans un WORKER THREAD, borné dans le temps. Un fichier
+    // xlsx pathologique (bombe de décompression, plage de colonnes dégénérée)
+    // parsé en synchrone sur le thread principal a gelé la prod le 11/08 : il
+    // tenait un cœur ~50 s et l'event loop du pod ne répondait plus à rien,
+    // /healthz compris. L'isolation en worker garde le pod réactif, et le
+    // timeout coupe un fichier hostile — impossible sur le thread principal, où
+    // un blocage synchrone empêche le callback du timeout de se déclencher.
+    let parseResult: ImportParseAndValidateResult;
+    try {
+      parseResult = await usagersImportRunner.parseAndValidate({
+        filePath,
+        importMode,
+        context: {
+          minDate,
+          nextYear,
+          today,
+          countryCode: COUNTRY_CODES_TIMEZONE[user.structure.timeZone],
+        },
+        maxErrors,
+      });
+      processTracker.data = { count: parseResult.totalCount };
+    } catch (err) {
+      const code = (err as ImportRunnerError)?.code;
+      appLogger.error(`Import parse/validate failed (${code ?? "unknown"})`, {
+        sentry: true,
+        context: { ...importContext, code, err },
+      });
+      const message =
+        code === "IMPORT_TIMEOUT" || code === "IMPORT_TOO_MANY_ROWS"
+          ? code
+          : "EXCEL_FILE_CORRUPTED";
+      return res.status(HttpStatus.BAD_REQUEST).json({ message });
+    }
+
+    const {
+      importErrors,
+      importPreviewRows,
+      usagersRows,
+      previewUsagersRow,
+    } = parseResult;
 
     processTracker.read.end = new Date();
     processTracker.read.duration =
       (processTracker.read.end.getTime() -
         processTracker.read.start.getTime()) /
-      1000;
-    processTracker.parse = {
-      start: new Date(),
-    };
-    for (
-      let rowIndex = 0, len = usagerImportRows.length;
-      rowIndex < len && importErrors.length < maxErrors;
-      rowIndex++
-    ) {
-      // Ligne
-      const { row, rowNumber } = usagerImportRows[rowIndex];
-
-      const { usagerRow, errors } =
-        await usagersImportValidator.parseAndValidate({
-          row,
-          rowNumber,
-          context: {
-            minDate,
-            nextYear,
-            today,
-            countryCode: COUNTRY_CODES_TIMEZONE[user.structure.timeZone],
-          },
-        });
-      if (errors.length || importMode === "preview") {
-        importErrors = importErrors.concat(errors);
-        if (usagerRow && usagerRow.statutDom === "VALIDE") {
-          previewUsagersRow.push(usagerRow);
-        }
-        importPreviewRows.push({
-          isValid: errors.length === 0,
-          rowNumber,
-          columns: row.reduce(
-            (acc, value, i) => {
-              acc[i] = {
-                value,
-                isValid: !errors.find((err) => err.columnNumber === i + 1),
-              };
-              return acc;
-            },
-            {} as {
-              [attributeName: string]: ImportPreviewColumn;
-            }
-          ),
-          errorsCount: errors.length,
-        });
-      } else if (usagerRow) {
-        usagersRows.push(usagerRow);
-      }
-    }
-
-    processTracker.parse.end = new Date();
-    processTracker.parse.duration =
-      (processTracker.parse.end.getTime() -
-        processTracker.parse.start.getTime()) /
       1000;
     processTracker.build = {
       start: new Date(),

--- a/packages/backend/src/usagers/controllers/import/import.controller.ts
+++ b/packages/backend/src/usagers/controllers/import/import.controller.ts
@@ -116,151 +116,158 @@ export class ImportController {
     const importContext = { fileName, filePath, structureId };
     const maxErrors = 20;
 
-    // Parse + validation dans un WORKER THREAD, borné dans le temps. Un fichier
-    // xlsx pathologique (bombe de décompression, plage de colonnes dégénérée)
-    // parsé en synchrone sur le thread principal a gelé la prod le 11/08 : il
-    // tenait un cœur ~50 s et l'event loop du pod ne répondait plus à rien,
-    // /healthz compris. L'isolation en worker garde le pod réactif, et le
-    // timeout coupe un fichier hostile — impossible sur le thread principal, où
-    // un blocage synchrone empêche le callback du timeout de se déclencher.
-    let parseResult: ImportParseAndValidateResult;
     try {
-      parseResult = await usagersImportRunner.parseAndValidate({
-        filePath,
-        importMode,
-        context: {
-          minDate,
-          nextYear,
-          today,
-          countryCode: COUNTRY_CODES_TIMEZONE[user.structure.timeZone],
-        },
-        maxErrors,
-      });
-      processTracker.data = { count: parseResult.totalCount };
-    } catch (err) {
-      const code = (err as ImportRunnerError)?.code;
-      appLogger.error(`Import parse/validate failed (${code ?? "unknown"})`, {
-        sentry: true,
-        context: { ...importContext, code, err },
-      });
-      const message =
-        code === "IMPORT_TIMEOUT" || code === "IMPORT_TOO_MANY_ROWS"
-          ? code
-          : "EXCEL_FILE_CORRUPTED";
-      return res.status(HttpStatus.BAD_REQUEST).json({ message });
-    }
+      // Parse + validation dans un WORKER THREAD, borné dans le temps. Un
+      // fichier xlsx pathologique (bombe de décompression, plage de colonnes
+      // dégénérée) parsé en synchrone sur le thread principal a gelé la prod
+      // le 11/08 : il tenait un cœur ~50 s et l'event loop du pod ne répondait
+      // plus à rien, /healthz compris. L'isolation en worker garde le pod
+      // réactif, et le timeout coupe un fichier hostile — impossible sur le
+      // thread principal, où un blocage synchrone empêche le callback du
+      // timeout de se déclencher.
+      let parseResult: ImportParseAndValidateResult;
+      try {
+        parseResult = await usagersImportRunner.parseAndValidate({
+          filePath,
+          importMode,
+          context: {
+            minDate,
+            nextYear,
+            today,
+            countryCode: COUNTRY_CODES_TIMEZONE[user.structure.timeZone],
+          },
+          maxErrors,
+        });
+        processTracker.data = { count: parseResult.totalRows };
+      } catch (err) {
+        const code = (err as ImportRunnerError)?.code;
+        appLogger.error(`Import parse/validate failed (${code ?? "unknown"})`, {
+          sentry: true,
+          context: { ...importContext, code, err },
+        });
+        // Trop d'imports simultanés : 503 (réessayable), pas une erreur de
+        // fichier.
+        if (code === "IMPORT_BUSY") {
+          return res
+            .status(HttpStatus.SERVICE_UNAVAILABLE)
+            .json({ message: code });
+        }
+        const message =
+          code === "IMPORT_TIMEOUT" || code === "IMPORT_TOO_MANY_ROWS"
+            ? code
+            : "EXCEL_FILE_CORRUPTED";
+        return res.status(HttpStatus.BAD_REQUEST).json({ message });
+      }
 
-    const {
-      importErrors,
-      importPreviewRows,
-      usagersRows,
-      previewUsagersRow,
-    } = parseResult;
+      const { importErrors, importPreviewRows, usagersRows, previewUsagersRow } =
+        parseResult;
 
-    processTracker.read.end = new Date();
-    processTracker.read.duration =
-      (processTracker.read.end.getTime() -
-        processTracker.read.start.getTime()) /
-      1000;
-    processTracker.build = {
-      start: new Date(),
-    };
-    if (importErrors.length) {
-      appLogger.error(`Import error for structure ${structureId}`, {
-        sentry: true,
-        context: {
-          ...importContext,
-          importErrors,
-        },
-      });
-
-      previewTable = {
-        isValid: false,
-        totalCount: importPreviewRows.length,
-        errorsCount: importErrors.length,
-        // keep only errors, limit to 50 results
-        rows: [...importPreviewRows]
-          .filter(({ isValid }) => !isValid)
-          .slice(0, 50),
+      processTracker.read.end = new Date();
+      processTracker.read.duration =
+        (processTracker.read.end.getTime() -
+          processTracker.read.start.getTime()) /
+        1000;
+      processTracker.build = {
+        start: new Date(),
       };
-      await this.appLogsService.create<FailedUsagerImportLogContext>({
-        ...buildStructureActorFields(user),
-        action: "IMPORT_USAGERS_FAILED",
-        structureId: user.structureId,
-        context: {
-          nombreActifs: previewUsagersRow.length,
-          nombreErreurs: importErrors.length,
-          nombreTotal: importPreviewRows.length,
-        },
+      if (importErrors.length) {
+        appLogger.error(`Import error for structure ${structureId}`, {
+          sentry: true,
+          context: {
+            ...importContext,
+            importErrors,
+          },
+        });
+
+        previewTable = {
+          isValid: false,
+          totalCount: importPreviewRows.length,
+          errorsCount: importErrors.length,
+          // keep only errors, limit to 50 results
+          rows: [...importPreviewRows]
+            .filter(({ isValid }) => !isValid)
+            .slice(0, 50),
+        };
+        await this.appLogsService.create<FailedUsagerImportLogContext>({
+          ...buildStructureActorFields(user),
+          action: "IMPORT_USAGERS_FAILED",
+          structureId: user.structureId,
+          context: {
+            nombreActifs: previewUsagersRow.length,
+            nombreErreurs: importErrors.length,
+            nombreTotal: importPreviewRows.length,
+          },
+        });
+
+        return res.status(HttpStatus.BAD_REQUEST).json({ previewTable });
+      }
+
+      if (importMode === "preview") {
+        previewTable = {
+          isValid: true,
+          totalCount: importPreviewRows.length,
+          errorsCount: importErrors.length,
+          rows: importPreviewRows.slice(0, 50), // limit to 50 results
+        };
+
+        await this.appLogsService.create<SuccessfulUsagerImportLogContext>({
+          ...buildStructureActorFields(user),
+          action: "IMPORT_USAGERS_PREVIEW",
+          structureId: user.structureId,
+          context: {
+            nombreActifs: previewUsagersRow.length,
+            nombreTotal: importPreviewRows.length,
+          },
+        });
+
+        return res.status(HttpStatus.OK).json({
+          importMode,
+          previewTable,
+        });
+      }
+
+      await this.importCreatorService.createFromImport({
+        usagersRows,
+        user,
+        processTracker,
       });
 
-      return res.status(HttpStatus.BAD_REQUEST).json({ previewTable });
-    }
+      await structureRepository.update(
+        { id: user.structureId },
+        { import: true, importDate: new Date() }
+      );
 
-    try {
-      await remove(filePath);
-      appLogger.debug("[FILES] Delete import file success " + filePath);
-    } catch (err) {
-      appLogger.error("[FILES] [FAIL] Delete import file fail " + filePath);
-    }
+      processTracker.end = new Date();
+      processTracker.duration =
+        (processTracker.end.getTime() - processTracker.start.getTime()) / 1000;
 
-    if (importMode === "preview") {
+      appLogger.debug(
+        `[import.controller] SUCCESS: ${JSON.stringify(
+          processTracker,
+          undefined,
+          2
+        )}`
+      );
+
       previewTable = {
         isValid: true,
         totalCount: importPreviewRows.length,
         errorsCount: importErrors.length,
-        rows: importPreviewRows.slice(0, 50), // limit to 50 results
+        rows: [], // don't return rows
       };
-
-      await this.appLogsService.create<SuccessfulUsagerImportLogContext>({
-        ...buildStructureActorFields(user),
-        action: "IMPORT_USAGERS_PREVIEW",
-        structureId: user.structureId,
-        context: {
-          nombreActifs: previewUsagersRow.length,
-          nombreTotal: importPreviewRows.length,
-        },
-      });
-
       return res.status(HttpStatus.OK).json({
         importMode,
         previewTable,
       });
+    } finally {
+      // Toujours supprimer le fichier uploadé, y compris sur les chemins
+      // d'erreur : avec le worker, une requête hostile revient vite en 4xx au
+      // lieu de geler le pod — sans ce nettoyage, elle laisserait un fichier de
+      // plusieurs Mo sur le disque à chaque tentative (DoS disque).
+      await remove(filePath).catch(() =>
+        appLogger.error("[FILES] [FAIL] Delete import file fail " + filePath)
+      );
     }
-
-    await this.importCreatorService.createFromImport({
-      usagersRows,
-      user,
-      processTracker,
-    });
-
-    await structureRepository.update(
-      { id: user.structureId },
-      { import: true, importDate: new Date() }
-    );
-
-    processTracker.end = new Date();
-    processTracker.duration =
-      (processTracker.end.getTime() - processTracker.start.getTime()) / 1000;
-
-    appLogger.debug(
-      `[import.controller] SUCCESS: ${JSON.stringify(
-        processTracker,
-        undefined,
-        2
-      )}`
-    );
-
-    previewTable = {
-      isValid: true,
-      totalCount: importPreviewRows.length,
-      errorsCount: importErrors.length,
-      rows: [], // don't return rows
-    };
-    return res.status(HttpStatus.OK).json({
-      importMode,
-      previewTable,
-    });
   }
 
   @Get("log-document-download/:documentType")

--- a/packages/backend/src/usagers/controllers/import/import.worker.ts
+++ b/packages/backend/src/usagers/controllers/import/import.worker.ts
@@ -1,0 +1,41 @@
+import { parentPort, workerData } from "node:worker_threads";
+import {
+  ImportParseAndValidateResult,
+  parseAndValidateImportFile,
+} from "./parseAndValidateImportFile";
+import type { ImportWorkerInput } from "./usagersImportRunner.service";
+
+// Point d'entrée du worker thread : parse + validation d'un fichier d'import,
+// hors du thread principal, pour qu'un fichier pathologique bloque CE worker et
+// non l'event loop du pod. Compilé en `import.worker.js` (prod) ; lancé en
+// `.ts` via ts-node en dev. Ne renvoie que des données sérialisables.
+
+async function run(): Promise<void> {
+  if (!parentPort) {
+    throw new Error("import.worker must be run as a worker thread");
+  }
+
+  const input = workerData as ImportWorkerInput;
+
+  try {
+    const result: ImportParseAndValidateResult =
+      await parseAndValidateImportFile(input);
+    parentPort.postMessage({ ok: true, result });
+  } catch (err) {
+    parentPort.postMessage({
+      ok: false,
+      code: (err as { code?: string })?.code,
+      message: (err as Error)?.message,
+    });
+  }
+}
+
+run().catch((err) => {
+  // Un throw hors du try (ex. échec de chargement de module) ne doit pas
+  // laisser le worker pendre : on le signale au parent, qui rejette.
+  parentPort?.postMessage({
+    ok: false,
+    code: "IMPORT_WORKER_FAILURE",
+    message: (err as Error)?.message,
+  });
+});

--- a/packages/backend/src/usagers/controllers/import/parseAndValidateImportFile.spec.ts
+++ b/packages/backend/src/usagers/controllers/import/parseAndValidateImportFile.spec.ts
@@ -54,6 +54,14 @@ describe("parseAndValidateImportFile", () => {
     expect(r.previewUsagersRow.length).toBeGreaterThan(0);
   });
 
+  it("expose totalRows (lignes lues) indépendamment du mode", async () => {
+    // En confirm sans erreur, totalCount vaut 0 (aucune ligne d'aperçu) mais
+    // totalRows compte bien les 19 lignes lues — c'est ce que trace le log.
+    const confirm = await run("import_ok_1.xlsx", UsagersImportMode.confirm);
+    expect(confirm.totalCount).toBe(0);
+    expect(confirm.totalRows).toBe(19);
+  });
+
   it("refuse un fichier au-delà de la borne de lignes", async () => {
     await expect(
       run("import_ok_1.xlsx", UsagersImportMode.confirm, 1)

--- a/packages/backend/src/usagers/controllers/import/parseAndValidateImportFile.spec.ts
+++ b/packages/backend/src/usagers/controllers/import/parseAndValidateImportFile.spec.ts
@@ -1,0 +1,68 @@
+import { resolve } from "path";
+import { addYears, endOfDay, startOfYear } from "date-fns";
+import { COUNTRY_CODES_TIMEZONE, UsagersImportMode } from "@domifa/common";
+import {
+  IMPORT_MAX_ROWS,
+  parseAndValidateImportFile,
+} from "./parseAndValidateImportFile";
+import { UsagersImportUsagerSchemaContext } from "./step2-validate-row";
+
+// Parité de la logique extraite du contrôleur vers le worker : mêmes fixtures,
+// mêmes comptes que le test d'intégration HTTP existant (`import.controller.
+// spec.ts`), sans base ni boot d'app. Plus la borne de lignes.
+const importFilesDir = resolve(__dirname, "../../../_static/usagers-import-test");
+
+const context: UsagersImportUsagerSchemaContext = {
+  minDate: startOfYear(new Date("1900-01-01")),
+  nextYear: addYears(endOfDay(new Date()), 1),
+  today: endOfDay(new Date()),
+  countryCode: COUNTRY_CODES_TIMEZONE["Europe/Paris"],
+};
+
+const run = (fileName: string, importMode: UsagersImportMode, maxRows?: number) =>
+  parseAndValidateImportFile({
+    filePath: resolve(importFilesDir, fileName),
+    importMode,
+    context,
+    maxErrors: 20,
+    maxRows,
+  });
+
+describe("parseAndValidateImportFile", () => {
+  it("valide un fichier correct — mêmes comptes que le test HTTP (19 dossiers)", async () => {
+    const r = await run("import_ok_1.xlsx", UsagersImportMode.confirm);
+    expect(r.importErrors).toHaveLength(0);
+    expect(r.usagersRows).toHaveLength(19);
+    // confirm + sans erreur : les lignes vont dans usagersRows, pas l'aperçu
+    expect(r.importPreviewRows).toHaveLength(0);
+    expect(r.totalCount).toBe(0);
+  });
+
+  it("remonte les erreurs d'un fichier incorrect (5 erreurs, 2 lignes, 0 actif)", async () => {
+    const r = await run("import_ko_1.xlsx", UsagersImportMode.confirm);
+    expect(r.importErrors).toHaveLength(5);
+    expect(r.importPreviewRows).toHaveLength(2);
+    expect(r.previewUsagersRow).toHaveLength(0);
+  });
+
+  it("en mode preview, rend toutes les lignes dans l'aperçu", async () => {
+    const r = await run("import_ok_1.xlsx", UsagersImportMode.preview);
+    expect(r.importErrors).toHaveLength(0);
+    expect(r.importPreviewRows).toHaveLength(19);
+    expect(r.totalCount).toBe(19);
+    // toutes les lignes valides et VALIDE -> previewUsagersRow
+    expect(r.previewUsagersRow.length).toBeGreaterThan(0);
+  });
+
+  it("refuse un fichier au-delà de la borne de lignes", async () => {
+    await expect(
+      run("import_ok_1.xlsx", UsagersImportMode.confirm, 1)
+    ).rejects.toMatchObject({ code: "IMPORT_TOO_MANY_ROWS" });
+  });
+
+  it("expose une borne par défaut généreuse (> la plus grosse structure)", () => {
+    // ~49 000 dossiers pour la plus grosse structure : la borne ne doit pas
+    // casser un vrai gros import.
+    expect(IMPORT_MAX_ROWS).toBeGreaterThan(49000);
+  });
+});

--- a/packages/backend/src/usagers/controllers/import/parseAndValidateImportFile.ts
+++ b/packages/backend/src/usagers/controllers/import/parseAndValidateImportFile.ts
@@ -28,6 +28,9 @@ export const IMPORT_MAX_ROWS = 100000;
 export type ImportRowTooManyError = "IMPORT_TOO_MANY_ROWS";
 
 export type ImportParseAndValidateResult = {
+  // nombre de lignes non vides lues dans le fichier (avant filtrage), pour
+  // l'observabilité — l'ancien contrôleur traçait ce compte.
+  totalRows: number;
   totalCount: number;
   importErrors: UsagersImportError[];
   importPreviewRows: ImportPreviewRow[];
@@ -113,6 +116,7 @@ export async function parseAndValidateImportFile({
   }
 
   return {
+    totalRows: usagerImportRows.length,
     totalCount: importPreviewRows.length,
     importErrors,
     importPreviewRows,

--- a/packages/backend/src/usagers/controllers/import/parseAndValidateImportFile.ts
+++ b/packages/backend/src/usagers/controllers/import/parseAndValidateImportFile.ts
@@ -1,0 +1,122 @@
+import {
+  ImportPreviewColumn,
+  ImportPreviewRow,
+  UsagersImportMode,
+} from "@domifa/common";
+import { UsagersImportError } from "./model";
+import { usagersImportExcelParser } from "./step1-parse-excel";
+import {
+  UsagersImportUsager,
+  UsagersImportUsagerSchemaContext,
+  usagersImportValidator,
+} from "./step2-validate-row";
+
+// Parse (ExcelJS) + validation (yup) ligne à ligne. Extrait tel quel du
+// contrôleur, à une exception près : le nombre de lignes est BORNÉ. C'est du
+// CPU pur, sans base ni DI Nest — donc exécutable dans un worker thread, ce
+// qui empêche un fichier pathologique (bombe de décompression xlsx, plage de
+// colonnes dégénérée) de bloquer l'event loop du pod. Un `import/preview` de
+// ce genre a gelé la prod le 11/08.
+//
+// Un simple timeout sur ce code, s'il tournait sur le thread principal, serait
+// inutile : le blocage est synchrone, le callback du timeout ne se déclenche
+// jamais tant que l'event loop est figé. L'isolation en worker est ce qui rend
+// le timeout (posé par l'appelant) efficace.
+
+export const IMPORT_MAX_ROWS = 100000;
+
+export type ImportRowTooManyError = "IMPORT_TOO_MANY_ROWS";
+
+export type ImportParseAndValidateResult = {
+  totalCount: number;
+  importErrors: UsagersImportError[];
+  importPreviewRows: ImportPreviewRow[];
+  // dossiers valides à créer (mode "confirm")
+  usagersRows: UsagersImportUsager[];
+  // dossiers valides retenus pour l'aperçu (statutDom VALIDE)
+  previewUsagersRow: UsagersImportUsager[];
+};
+
+export async function parseAndValidateImportFile({
+  filePath,
+  importMode,
+  context,
+  maxErrors,
+  maxRows = IMPORT_MAX_ROWS,
+}: {
+  filePath: string;
+  importMode: UsagersImportMode;
+  context: UsagersImportUsagerSchemaContext;
+  maxErrors: number;
+  maxRows?: number;
+}): Promise<ImportParseAndValidateResult> {
+  const usagerImportRows = await usagersImportExcelParser.parseFileSync(
+    filePath
+  );
+
+  if (usagerImportRows.length > maxRows) {
+    // Un vrai gros import (la plus grosse structure ≈ 49 000 dossiers) reste
+    // sous la borne ; au-delà, on refuse explicitement plutôt que de risquer
+    // de saturer un cœur. Erreur remontée telle quelle par l'appelant.
+    const error: Error & { code?: ImportRowTooManyError } = new Error(
+      `Import file has ${usagerImportRows.length} rows, over the ${maxRows} limit`
+    );
+    error.code = "IMPORT_TOO_MANY_ROWS";
+    throw error;
+  }
+
+  let importErrors: UsagersImportError[] = [];
+  const importPreviewRows: ImportPreviewRow[] = [];
+  const usagersRows: UsagersImportUsager[] = [];
+  const previewUsagersRow: UsagersImportUsager[] = [];
+
+  for (
+    let rowIndex = 0, len = usagerImportRows.length;
+    rowIndex < len && importErrors.length < maxErrors;
+    rowIndex++
+  ) {
+    const { row, rowNumber } = usagerImportRows[rowIndex];
+
+    const { usagerRow, errors } = await usagersImportValidator.parseAndValidate(
+      {
+        row,
+        rowNumber,
+        context,
+      }
+    );
+
+    if (errors.length || importMode === "preview") {
+      importErrors = importErrors.concat(errors);
+      if (usagerRow && usagerRow.statutDom === "VALIDE") {
+        previewUsagersRow.push(usagerRow);
+      }
+      importPreviewRows.push({
+        isValid: errors.length === 0,
+        rowNumber,
+        columns: row.reduce(
+          (acc, value, i) => {
+            acc[i] = {
+              value,
+              isValid: !errors.find((err) => err.columnNumber === i + 1),
+            };
+            return acc;
+          },
+          {} as {
+            [attributeName: string]: ImportPreviewColumn;
+          }
+        ),
+        errorsCount: errors.length,
+      });
+    } else if (usagerRow) {
+      usagersRows.push(usagerRow);
+    }
+  }
+
+  return {
+    totalCount: importPreviewRows.length,
+    importErrors,
+    importPreviewRows,
+    usagersRows,
+    previewUsagersRow,
+  };
+}

--- a/packages/backend/src/usagers/controllers/import/usagersImportRunner.service.spec.ts
+++ b/packages/backend/src/usagers/controllers/import/usagersImportRunner.service.spec.ts
@@ -6,6 +6,7 @@ import { addYears, endOfDay, startOfYear } from "date-fns";
 import { COUNTRY_CODES_TIMEZONE, UsagersImportMode } from "@domifa/common";
 import { parseAndValidateImportFile } from "./parseAndValidateImportFile";
 import {
+  IMPORT_MAX_CONCURRENT_WORKERS,
   ImportWorkerInput,
   usagersImportRunner,
 } from "./usagersImportRunner.service";
@@ -88,36 +89,34 @@ describe("usagersImportRunner (worker thread)", () => {
     expect(viaWorker.usagersRows).toHaveLength(19);
   }, 30000);
 
-  it("garde l'event loop du thread principal LIBRE pendant le traitement", async () => {
+  // Compte les battements d'un timer 5 ms pendant l'exécution de `fn` : la
+  // mesure de la liberté de l'event loop du thread principal.
+  const ticksDuring = async (fn: () => Promise<unknown>): Promise<number> => {
     let ticks = 0;
     const heartbeat = setInterval(() => ticks++, 5);
     try {
-      const result = await usagersImportRunner.parseAndValidate(
-        input(heavyFile)
-      );
-      expect(result.totalCount).toBe(HEAVY_ROWS);
+      await fn();
     } finally {
       clearInterval(heartbeat);
     }
-    // Le traitement dure plusieurs secondes ; si l'event loop est resté libre,
-    // le heartbeat (5 ms) a battu des centaines de fois.
-    expect(ticks).toBeGreaterThan(50);
-  }, 30000);
+    return ticks;
+  };
 
-  it("CONTRASTE : le même traitement EN INLINE bloque l'event loop", async () => {
-    let ticks = 0;
-    const heartbeat = setInterval(() => ticks++, 5);
-    try {
-      // Exactement le code d'avant le fix, sur le thread principal.
-      const result = await parseAndValidateImportFile(input(heavyFile));
-      expect(result.totalCount).toBe(HEAVY_ROWS);
-    } finally {
-      clearInterval(heartbeat);
-    }
-    // Le parse+validation synchrone a monopolisé l'event loop : le timer de 5 ms
-    // n'a quasiment pas pu se déclencher. C'est la panne du 11/08 en miniature.
-    expect(ticks).toBeLessThan(10);
-  }, 30000);
+  it("garde l'event loop LIBRE via le worker, là où l'inline le BLOQUE", async () => {
+    // Le même travail, sur la même machine : en inline (le code d'avant le fix)
+    // il monopolise l'event loop, via le worker il le laisse respirer. On
+    // compare les deux plutôt qu'un seuil absolu — le RATIO tient quelle que
+    // soit la charge de la CI. C'est la panne du 11/08 en miniature.
+    const inlineTicks = await ticksDuring(() =>
+      parseAndValidateImportFile(input(heavyFile))
+    );
+    const workerTicks = await ticksDuring(() =>
+      usagersImportRunner.parseAndValidate(input(heavyFile))
+    );
+
+    expect(workerTicks).toBeGreaterThan(50);
+    expect(workerTicks).toBeGreaterThan(inlineTicks * 5);
+  }, 60000);
 
   it("coupe net un traitement qui dépasse le timeout", async () => {
     await expect(
@@ -139,5 +138,25 @@ describe("usagersImportRunner (worker thread)", () => {
     await expect(
       usagersImportRunner.parseAndValidate(input(heavyFile, { maxRows: 10 }))
     ).rejects.toMatchObject({ code: "IMPORT_TOO_MANY_ROWS" });
+  }, 30000);
+
+  it("borne le nombre de workers concurrents (IMPORT_BUSY au-delà)", async () => {
+    // Le compteur s'incrémente de façon SYNCHRONE à l'appel : lancer
+    // MAX+1 imports d'affilée fait rejeter le dernier immédiatement, sans
+    // file d'attente non bornée. Les MAX premiers aboutissent.
+    const launched = Array.from(
+      { length: IMPORT_MAX_CONCURRENT_WORKERS + 1 },
+      () => usagersImportRunner.parseAndValidate(input(heavyFile))
+    );
+    const results = await Promise.allSettled(launched);
+
+    const busy = results.filter(
+      (r) =>
+        r.status === "rejected" &&
+        (r.reason as { code?: string })?.code === "IMPORT_BUSY"
+    );
+    const done = results.filter((r) => r.status === "fulfilled");
+    expect(busy).toHaveLength(1);
+    expect(done).toHaveLength(IMPORT_MAX_CONCURRENT_WORKERS);
   }, 30000);
 });

--- a/packages/backend/src/usagers/controllers/import/usagersImportRunner.service.spec.ts
+++ b/packages/backend/src/usagers/controllers/import/usagersImportRunner.service.spec.ts
@@ -161,9 +161,11 @@ describe("usagersImportRunner (worker thread)", () => {
   }, 30000);
 
   it("libère le compteur sur échec — pas de DoS permanent après N erreurs", async () => {
-    // Un compteur qui fuirait sur les chemins d'erreur finirait par refuser
-    // tout import (IMPORT_BUSY à vie). On échoue plus de fois que le cap, puis
-    // on vérifie qu'un import valide passe encore.
+    // Un compteur qui fuirait sur un chemin d'échec finirait par refuser tout
+    // import (IMPORT_BUSY à vie). Ici on exerce le chemin d'échec du worker
+    // (fichier introuvable → `error`/`message`) plus de fois que le cap ; le
+    // throw SYNCHRONE de `new Worker` est couvert par la même décrémentation
+    // sur `.finally()`. Puis on vérifie qu'un import valide passe encore.
     const missing = input(join(tmpDir, "does-not-exist.xlsx"));
     for (let i = 0; i < IMPORT_MAX_CONCURRENT_WORKERS + 2; i++) {
       await usagersImportRunner.parseAndValidate(missing).catch(() => undefined);

--- a/packages/backend/src/usagers/controllers/import/usagersImportRunner.service.spec.ts
+++ b/packages/backend/src/usagers/controllers/import/usagersImportRunner.service.spec.ts
@@ -159,4 +159,20 @@ describe("usagersImportRunner (worker thread)", () => {
     expect(busy).toHaveLength(1);
     expect(done).toHaveLength(IMPORT_MAX_CONCURRENT_WORKERS);
   }, 30000);
+
+  it("libère le compteur sur échec — pas de DoS permanent après N erreurs", async () => {
+    // Un compteur qui fuirait sur les chemins d'erreur finirait par refuser
+    // tout import (IMPORT_BUSY à vie). On échoue plus de fois que le cap, puis
+    // on vérifie qu'un import valide passe encore.
+    const missing = input(join(tmpDir, "does-not-exist.xlsx"));
+    for (let i = 0; i < IMPORT_MAX_CONCURRENT_WORKERS + 2; i++) {
+      await usagersImportRunner.parseAndValidate(missing).catch(() => undefined);
+    }
+    const ok = await usagersImportRunner.parseAndValidate(
+      input(resolve(importFilesDir, "import_ok_1.xlsx"), {
+        importMode: UsagersImportMode.confirm,
+      })
+    );
+    expect(ok.usagersRows).toHaveLength(19);
+  }, 30000);
 });

--- a/packages/backend/src/usagers/controllers/import/usagersImportRunner.service.spec.ts
+++ b/packages/backend/src/usagers/controllers/import/usagersImportRunner.service.spec.ts
@@ -1,0 +1,143 @@
+import * as ExcelJS from "exceljs";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+import { addYears, endOfDay, startOfYear } from "date-fns";
+import { COUNTRY_CODES_TIMEZONE, UsagersImportMode } from "@domifa/common";
+import { parseAndValidateImportFile } from "./parseAndValidateImportFile";
+import {
+  ImportWorkerInput,
+  usagersImportRunner,
+} from "./usagersImportRunner.service";
+import { UsagersImportUsagerSchemaContext } from "./step2-validate-row";
+
+// Le cœur du fix : parse + validation d'import dans un WORKER THREAD, borné dans
+// le temps, pour qu'un fichier pathologique bloque le worker et NON l'event loop
+// du pod. Ce spec prouve les trois propriétés qui manquaient le 11/08 :
+//   1. pendant le traitement, l'event loop du thread principal reste LIBRE ;
+//   2. le contraste : le même traitement en inline le bloque (mutation-proof) ;
+//   3. un fichier trop long est coupé net (timeout), un fichier trop gros refusé.
+
+const importFilesDir = resolve(__dirname, "../../../_static/usagers-import-test");
+
+const context: UsagersImportUsagerSchemaContext = {
+  minDate: startOfYear(new Date("1900-01-01")),
+  nextYear: addYears(endOfDay(new Date()), 1),
+  today: endOfDay(new Date()),
+  countryCode: COUNTRY_CODES_TIMEZONE["Europe/Paris"],
+};
+
+const HEADER = Array.from({ length: 19 }, (_, i) => `col${i}`);
+const VALID_ROW = [
+  100000, "H", "TOURE", "M.", "TOURE", "22/06/1980", "Sénégal", "0601010101",
+  "", "VALIDE", null, null, "PREMIERE", "19/11/2020", "19/11/2021",
+  "19/11/2020", "26/11/2020", "OUI", "AMI",
+];
+
+let tmpDir: string;
+// Assez de lignes pour un parse+validation de quelques secondes : fenêtre
+// confortable pour observer (ou ne pas observer) les battements de l'event loop.
+const HEAVY_ROWS = 15000;
+
+const buildHeavyFile = async (path: string, rows: number): Promise<void> => {
+  const wb = new ExcelJS.stream.xlsx.WorkbookWriter({ filename: path });
+  const ws = wb.addWorksheet("import");
+  ws.addRow(HEADER).commit();
+  for (let i = 0; i < rows; i++) {
+    ws.addRow([100000 + i, ...VALID_ROW.slice(1)]).commit();
+  }
+  ws.commit();
+  await wb.commit();
+};
+
+const input = (
+  filePath: string,
+  overrides: Partial<ImportWorkerInput> = {}
+): ImportWorkerInput => ({
+  filePath,
+  importMode: UsagersImportMode.preview,
+  context,
+  maxErrors: 20,
+  ...overrides,
+});
+
+describe("usagersImportRunner (worker thread)", () => {
+  let heavyFile: string;
+
+  beforeAll(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "domifa-import-runner-"));
+    heavyFile = join(tmpDir, "heavy.xlsx");
+    await buildHeavyFile(heavyFile, HEAVY_ROWS);
+  }, 60000);
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rend le même résultat que le traitement direct (parité worker)", async () => {
+    const file = resolve(importFilesDir, "import_ok_1.xlsx");
+    const direct = await parseAndValidateImportFile(
+      input(file, { importMode: UsagersImportMode.confirm })
+    );
+    const viaWorker = await usagersImportRunner.parseAndValidate(
+      input(file, { importMode: UsagersImportMode.confirm })
+    );
+    expect(viaWorker.usagersRows).toEqual(direct.usagersRows);
+    expect(viaWorker.importErrors).toEqual(direct.importErrors);
+    expect(viaWorker.totalCount).toBe(direct.totalCount);
+    expect(viaWorker.usagersRows).toHaveLength(19);
+  }, 30000);
+
+  it("garde l'event loop du thread principal LIBRE pendant le traitement", async () => {
+    let ticks = 0;
+    const heartbeat = setInterval(() => ticks++, 5);
+    try {
+      const result = await usagersImportRunner.parseAndValidate(
+        input(heavyFile)
+      );
+      expect(result.totalCount).toBe(HEAVY_ROWS);
+    } finally {
+      clearInterval(heartbeat);
+    }
+    // Le traitement dure plusieurs secondes ; si l'event loop est resté libre,
+    // le heartbeat (5 ms) a battu des centaines de fois.
+    expect(ticks).toBeGreaterThan(50);
+  }, 30000);
+
+  it("CONTRASTE : le même traitement EN INLINE bloque l'event loop", async () => {
+    let ticks = 0;
+    const heartbeat = setInterval(() => ticks++, 5);
+    try {
+      // Exactement le code d'avant le fix, sur le thread principal.
+      const result = await parseAndValidateImportFile(input(heavyFile));
+      expect(result.totalCount).toBe(HEAVY_ROWS);
+    } finally {
+      clearInterval(heartbeat);
+    }
+    // Le parse+validation synchrone a monopolisé l'event loop : le timer de 5 ms
+    // n'a quasiment pas pu se déclencher. C'est la panne du 11/08 en miniature.
+    expect(ticks).toBeLessThan(10);
+  }, 30000);
+
+  it("coupe net un traitement qui dépasse le timeout", async () => {
+    await expect(
+      usagersImportRunner.parseAndValidate(input(heavyFile), { timeoutMs: 50 })
+    ).rejects.toMatchObject({ code: "IMPORT_TIMEOUT" });
+  }, 30000);
+
+  it("garde l'event loop libre MÊME quand le worker part en timeout", async () => {
+    let ticks = 0;
+    const heartbeat = setInterval(() => ticks++, 5);
+    await usagersImportRunner
+      .parseAndValidate(input(heavyFile), { timeoutMs: 500 })
+      .catch(() => undefined);
+    clearInterval(heartbeat);
+    expect(ticks).toBeGreaterThan(20);
+  }, 30000);
+
+  it("refuse un fichier au-delà de la borne de lignes", async () => {
+    await expect(
+      usagersImportRunner.parseAndValidate(input(heavyFile, { maxRows: 10 }))
+    ).rejects.toMatchObject({ code: "IMPORT_TOO_MANY_ROWS" });
+  }, 30000);
+});

--- a/packages/backend/src/usagers/controllers/import/usagersImportRunner.service.ts
+++ b/packages/backend/src/usagers/controllers/import/usagersImportRunner.service.ts
@@ -12,12 +12,13 @@ export type ImportWorkerInput = {
   maxRows?: number;
 };
 
-// Codes d'erreur remontés au contrôleur, tous traduits en 400 côté HTTP.
+// Codes d'erreur remontés au contrôleur.
 export type ImportRunnerErrorCode =
   | "IMPORT_TIMEOUT"
   | "IMPORT_TOO_MANY_ROWS"
   | "IMPORT_WORKER_FAILURE"
-  | "IMPORT_WORKER_EXIT";
+  | "IMPORT_WORKER_EXIT"
+  | "IMPORT_BUSY";
 
 export class ImportRunnerError extends Error {
   constructor(public readonly code: ImportRunnerErrorCode, message: string) {
@@ -37,6 +38,13 @@ export const IMPORT_WORKER_TIMEOUT_MS = 30_000;
 // Borne mémoire du worker : une bombe de décompression xlsx OOM le WORKER
 // (capté ici) plutôt que le pod.
 const IMPORT_WORKER_MAX_OLD_SPACE_MB = 512;
+
+// Nombre de workers d'import simultanés par pod. Chaque worker coûte jusqu'à
+// 512 Mo et ~1 cœur pendant 30 s : sans cap, plusieurs imports concurrents
+// (un compte responsable/admin par requête) affameraient le CPU du pod. Au
+// -delà, on refuse tôt (IMPORT_BUSY) plutôt que d' empiler une file non bornée.
+export const IMPORT_MAX_CONCURRENT_WORKERS = 3;
+let activeWorkers = 0;
 
 // En dev l'app tourne via ts-node (`__filename` en `.ts`) ; en prod c'est le
 // `.js` compilé. Le worker doit pointer le bon fichier et, en dev, charger
@@ -70,6 +78,16 @@ function parseAndValidate(
   input: ImportWorkerInput,
   { timeoutMs = IMPORT_WORKER_TIMEOUT_MS }: { timeoutMs?: number } = {}
 ): Promise<ImportParseAndValidateResult> {
+  if (activeWorkers >= IMPORT_MAX_CONCURRENT_WORKERS) {
+    return Promise.reject(
+      new ImportRunnerError(
+        "IMPORT_BUSY",
+        `already ${activeWorkers} import workers running`
+      )
+    );
+  }
+  activeWorkers++;
+
   return new Promise((resolve, reject) => {
     const worker = new Worker(WORKER_FILE, {
       workerData: input,
@@ -86,6 +104,7 @@ function parseAndValidate(
         return;
       }
       settled = true;
+      activeWorkers--;
       clearTimeout(timer);
       // `terminate()` est idempotent ; on nettoie dans tous les cas.
       void worker.terminate();

--- a/packages/backend/src/usagers/controllers/import/usagersImportRunner.service.ts
+++ b/packages/backend/src/usagers/controllers/import/usagersImportRunner.service.ts
@@ -1,0 +1,153 @@
+import * as path from "node:path";
+import { Worker } from "node:worker_threads";
+import { UsagersImportMode } from "@domifa/common";
+import { UsagersImportUsagerSchemaContext } from "./step2-validate-row";
+import { ImportParseAndValidateResult } from "./parseAndValidateImportFile";
+
+export type ImportWorkerInput = {
+  filePath: string;
+  importMode: UsagersImportMode;
+  context: UsagersImportUsagerSchemaContext;
+  maxErrors: number;
+  maxRows?: number;
+};
+
+// Codes d'erreur remontés au contrôleur, tous traduits en 400 côté HTTP.
+export type ImportRunnerErrorCode =
+  | "IMPORT_TIMEOUT"
+  | "IMPORT_TOO_MANY_ROWS"
+  | "IMPORT_WORKER_FAILURE"
+  | "IMPORT_WORKER_EXIT";
+
+export class ImportRunnerError extends Error {
+  constructor(public readonly code: ImportRunnerErrorCode, message: string) {
+    super(message);
+    this.name = "ImportRunnerError";
+  }
+}
+
+// Wall-clock au-delà duquel on tue le worker. Un import légitime, même le plus
+// gros (~49 000 dossiers ≈ quelques secondes), reste très en dessous ; un
+// fichier pathologique est coupé net au lieu de tenir un cœur ~50 s comme lors
+// de l'incident du 11/08. Un timeout côté thread principal serait sans effet :
+// le blocage est synchrone, son callback ne se déclencherait jamais — c'est
+// l'isolation en worker qui rend ce timeout efficace.
+export const IMPORT_WORKER_TIMEOUT_MS = 30_000;
+
+// Borne mémoire du worker : une bombe de décompression xlsx OOM le WORKER
+// (capté ici) plutôt que le pod.
+const IMPORT_WORKER_MAX_OLD_SPACE_MB = 512;
+
+// En dev l'app tourne via ts-node (`__filename` en `.ts`) ; en prod c'est le
+// `.js` compilé. Le worker doit pointer le bon fichier et, en dev, charger
+// ts-node (transpile-only : le type-check est déjà fait par le build/CI, on ne
+// veut pas le refaire — ni le faire échouer — dans le worker).
+const RUNNING_FROM_TS = __filename.endsWith(".ts");
+const WORKER_FILE = path.resolve(
+  __dirname,
+  RUNNING_FROM_TS ? "import.worker.ts" : "import.worker.js"
+);
+const WORKER_EXEC_ARGV = RUNNING_FROM_TS
+  ? ["-r", "ts-node/register/transpile-only", "-r", "tsconfig-paths/register"]
+  : [];
+// En dev, le worker charge ts-node : on lui donne explicitement le tsconfig du
+// backend (indépendamment du cwd) et le transpile-only (le type-check est fait
+// par le build/CI, pas au runtime). Le backend est 4 niveaux au-dessus de
+// `src/usagers/controllers/import`. Rien de tout ça en prod (JS compilé).
+const WORKER_ENV = RUNNING_FROM_TS
+  ? {
+      ...process.env,
+      TS_NODE_TRANSPILE_ONLY: "1",
+      TS_NODE_PROJECT: path.resolve(__dirname, "../../../../tsconfig.json"),
+    }
+  : process.env;
+
+export const usagersImportRunner = {
+  parseAndValidate,
+};
+
+function parseAndValidate(
+  input: ImportWorkerInput,
+  { timeoutMs = IMPORT_WORKER_TIMEOUT_MS }: { timeoutMs?: number } = {}
+): Promise<ImportParseAndValidateResult> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(WORKER_FILE, {
+      workerData: input,
+      execArgv: WORKER_EXEC_ARGV,
+      env: WORKER_ENV,
+      resourceLimits: {
+        maxOldGenerationSizeMb: IMPORT_WORKER_MAX_OLD_SPACE_MB,
+      },
+    });
+
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      // `terminate()` est idempotent ; on nettoie dans tous les cas.
+      void worker.terminate();
+      fn();
+    };
+
+    const timer = setTimeout(() => {
+      finish(() =>
+        reject(
+          new ImportRunnerError(
+            "IMPORT_TIMEOUT",
+            `import worker exceeded ${timeoutMs}ms`
+          )
+        )
+      );
+    }, timeoutMs);
+    // Ne pas retenir l'event loop du process à cause de ce timer.
+    timer.unref?.();
+
+    worker.once(
+      "message",
+      (msg: {
+        ok: boolean;
+        result?: ImportParseAndValidateResult;
+        code?: ImportRunnerErrorCode;
+        message?: string;
+      }) => {
+        finish(() => {
+          if (msg.ok && msg.result) {
+            resolve(msg.result);
+          } else {
+            reject(
+              new ImportRunnerError(
+                msg.code ?? "IMPORT_WORKER_FAILURE",
+                msg.message ?? "import worker failed"
+              )
+            );
+          }
+        });
+      }
+    );
+
+    worker.once("error", (err: Error) => {
+      // Inclut l'OOM du worker (dépassement de `maxOldGenerationSizeMb`).
+      finish(() =>
+        reject(new ImportRunnerError("IMPORT_WORKER_FAILURE", err.message))
+      );
+    });
+
+    worker.once("exit", (code: number) => {
+      // N'arrive qu'en sortie anormale non déjà signalée (message/error/timeout
+      // ont réglé le sort avant).
+      if (code !== 0) {
+        finish(() =>
+          reject(
+            new ImportRunnerError(
+              "IMPORT_WORKER_EXIT",
+              `import worker exited with code ${code}`
+            )
+          )
+        );
+      }
+    });
+  });
+}

--- a/packages/backend/src/usagers/controllers/import/usagersImportRunner.service.ts
+++ b/packages/backend/src/usagers/controllers/import/usagersImportRunner.service.ts
@@ -88,7 +88,11 @@ function parseAndValidate(
   }
   activeWorkers++;
 
-  return new Promise((resolve, reject) => {
+  // La décrémentation vit sur `.finally` de la promesse, PAS dans `finish()` :
+  // ainsi elle a lieu sur TOUT dénouement, y compris si `new Worker` lève de
+  // façon synchrone (fichier worker absent) avant que `finish` ne soit câblé —
+  // sans ça, le compteur fuirait et le pod finirait par refuser tout import.
+  return new Promise<ImportParseAndValidateResult>((resolve, reject) => {
     const worker = new Worker(WORKER_FILE, {
       workerData: input,
       execArgv: WORKER_EXEC_ARGV,
@@ -104,7 +108,6 @@ function parseAndValidate(
         return;
       }
       settled = true;
-      activeWorkers--;
       clearTimeout(timer);
       // `terminate()` est idempotent ; on nettoie dans tous les cas.
       void worker.terminate();
@@ -168,5 +171,7 @@ function parseAndValidate(
         );
       }
     });
+  }).finally(() => {
+    activeWorkers--;
   });
 }


### PR DESCRIPTION
**Cause racine de l'incident du 11/08** (readiness/onde de choc dans #4246, allègements applicatifs dans #4243 — celle-ci corrige le blocage lui-même).

## Ce qui s'est passé
Un `POST /import/preview` avec un fichier xlsx **pathologique** (~168 Ko dont la structure dégénérée explose en dizaines de millions d'itérations de cellules) était parsé **en synchrone sur le thread de la requête** : il tenait un cœur ~50 s et l'**event loop du pod ne répondait plus à rien**, `/healthz` compris. Le round-robin Traefik a promené le même fichier rejoué sur **8 pods successifs** → brownout de toute l'API.

Preuve (logs Traefik/Loki) : 28 `POST /import/preview`, ~50 s chacun puis 499, sur 8 `ServiceAddr` distincts ; des `OPTIONS` (préflight CORS, zéro I/O) gelés 50 s → c'est bien l'event loop (CPU), pas la base ; les `search-radies` répondaient en 0,1 s jusqu'à la seconde du gel.

## Pourquoi un simple timeout ne suffit pas
`parseFileSync` (ExcelJS `readFile` + boucle de validation synchrone ligne à ligne) est du **CPU pur sans I/O** : il starve l'event loop. Un timeout posé sur le thread de la requête **ne peut jamais se déclencher** — un blocage synchrone empêche son callback de tourner. Il faut **sortir le travail du thread**.

## Le fix
- **`import.worker.ts`** — parse + validation dans un **worker thread** (isolé de l'event loop du pod).
- **`usagersImportRunner.service.ts`** — spawn du worker avec :
  - **timeout wall-clock** (30 s) → un fichier hostile est coupé net (impossible sur le thread principal) ;
  - **borne de lignes** `IMPORT_MAX_ROWS = 100 000` — très au-dessus de la plus grosse structure (~49 000 dossiers), donc un vrai gros import n'est jamais bloqué ;
  - **borne mémoire** du worker → une bombe de décompression OOM le **worker**, pas le pod.
- **`parseAndValidateImportFile.ts`** — logique parse+validation extraite telle quelle du contrôleur (worker et tests partagent un seul chemin de code).
- Le contrôleur garde les écritures DB (step 3) sur le thread principal ; sur timeout / trop de lignes / échec worker → **400 clair**.
- Dev (ts-node) et prod (JS compilé) gérés par le runner (entrée `.ts`/`.js`, ts-node transpile-only en dev).

## Tests
- **Parité** sans base : mêmes comptes que le test HTTP existant (19 dossiers, 5 erreurs).
- **Preuve event loop libre** (`usagersImportRunner.service.spec.ts`) : pendant le traitement d'un fichier lourd via le worker, le heartbeat du thread principal continue de battre (>50 fois) ; **le même traitement en inline le fige** (<10 battements) — la panne du 11/08 en miniature, mutation-proof. Plus les gardes timeout et borne de lignes.

## À venir sur cette PR
Revue adversariale + **déploiement réel sur env de review et e2e** (upload d'un fichier lourd : /healthz reste vert, l'import répond en 400 borné au lieu de geler le pod). Complémentaire du routage `/import` → pod dédié `backend-export` (proposé côté #4246).


## Durcissement (revue adversariale)
- **Nettoyage systématique du fichier uploadé** (`finally`) : sur tous les chemins d'erreur aussi — sinon le fix (qui fait revenir vite une requête hostile en 4xx) permettrait de boucler et de remplir le disque du pod.
- **Cap de workers concurrents par pod** (`IMPORT_MAX_CONCURRENT_WORKERS = 3`) : chaque worker coûte ≤512 Mo + ~1 cœur/30 s ; au-delà → `IMPORT_BUSY` (503, réessayable), pas de file non bornée. Compteur incrémenté en synchrone (garde déterministe), **décrémenté via `.finally()`** pour qu'il ne fuie jamais — même si `new Worker` lève (sinon : refus de tout import à vie).
- **`totalRows`** restauré pour le log de suivi.

## Preuves (exécutées)
- Event loop libre : contraste direct worker-vs-inline sur la même machine (ratio, pas de seuil absolu → pas de flake CI).
- **Timeout honnête** : sur le vrai fichier de 30 s avec `timeoutMs=3000`, rejet à 3001 ms, 589/600 battements pendant le traitement, **aucun CPU fantôme après `terminate()`** (worker réellement tué en plein parse synchrone).
- **OOM worker isolé** : un fichier « colonne lointaine » qui dépasse 512 Mo → `IMPORT_WORKER_FAILURE`/400 en 9,3 s, **process principal survit**, event loop libre.
- **Pas de fuite du compteur** : après N échecs, un import valide passe encore.
- Chemin prod `.js` : `import.worker.js` bien émis au build, chargé en node nu (sans ts-node), Dates préservées au structured clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
