### PR TITLE
fix(ci): route /import to the dedicated backend-export pod

### DIFF
--- a/.kontinuous/env/dev/values.yaml
+++ b/.kontinuous/env/dev/values.yaml
@@ -63,6 +63,7 @@ backend-export:
   ~needs: [pg]
   ingress:
     paths:
+      - /import
       - /export
       - /admin/structures/export
       - /stats

--- a/.kontinuous/env/preprod/values.yaml
+++ b/.kontinuous/env/preprod/values.yaml
@@ -51,6 +51,7 @@ backend-export:
     oblik.socialgouv.io/request-apply-target: peak
   ingress:
     paths:
+      - /import
       - /export
       - /admin/structures/export
       - /stats

--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -105,6 +105,7 @@ backend-export:
   env: *backendEnv
   ingress:
     paths:
+      - /import
       - /export
       - /admin/structures/export
       - /stats

--- a/.kontinuous/values.yaml
+++ b/.kontinuous/values.yaml
@@ -67,6 +67,9 @@ backend-export:
   containerPort: 3000
   ingress:
     paths:
+      # /import routé sur ce pod dédié : son parse synchrone lourd (preview/confirm)
+      # ne doit pas geler l'event loop des pods backend qui servent le reste de l'API.
+      - /import
       - /export
       - /stats
       - /stats/home


### PR DESCRIPTION
## Pourquoi

Le parse de `/import` (preview/confirm) est **synchrone et lourd en CPU**. Sur les pods `backend` qui servent l'API, il **bloque l'event loop** → `/healthz` ne répond plus → la liveness tue le pod → quand plusieurs gèlent ensemble, **503 sur toute l'API**. C'est l'incident du 11/08, qui a **rejoué en direct le 12/08** (un seul utilisateur martelant `POST /import/preview` avec un xlsx ~160 Ko, ~50 s de gel par requête).

## Ce que fait la PR

`backend-export` existe déjà pour tenir les charges lourdes (`/export`, `/stats`) à l'écart des pods qui servent l'API. On y route aussi `/import`.

- `ingress.pathType` = `Prefix` (défaut du chart) → `/import` couvre `/import/preview`, `/import/confirm`, `/import/log-document-download/...`.
- Ajouté dans **les 4 fichiers** de values (`base` + `prod`/`preprod`/`dev`) car les overrides d'env **remplacent** la liste des paths au lieu de la fusionner.
- Un import pathologique ne dégrade alors **que les pods export**, pas le reste de DomiFa.

## Complémentaire

- **#4248** (parse dans un worker thread) : le vrai fix de la cause racine. Cette PR est de la **défense en profondeur** — le blast radius est contenu même là où le worker n'est pas encore déployé.
- **#4246** (readiness httpGet + drain) : bénéficie maintenant aussi à `backend-export` (drain d'un pod export gelé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)