### PR TITLE
fix(backend): preserve PENDING status on password reset

### DIFF
--- a/packages/backend/src/modules/users/services/tests/userSecurityResetPasswordUpdater.service.spec.ts
+++ b/packages/backend/src/modules/users/services/tests/userSecurityResetPasswordUpdater.service.spec.ts
@@ -1,0 +1,57 @@
+const repository = {
+  findOneBy: jest.fn(),
+  findOneByOrFail: jest.fn(),
+};
+const securityRepository = {
+  findOneByOrFail: jest.fn(),
+  update: jest.fn(),
+};
+const applyNewPassword = jest.fn();
+
+jest.mock("../get-user-repository.service", () => ({
+  getUserRepository: () => repository,
+  getUserSecurityRepository: () => securityRepository,
+}));
+jest.mock("../../../app-logs/app-log-security-writer", () => ({
+  logSecurityEventForUser: jest.fn(),
+}));
+jest.mock("../userPasswordWriter.service", () => ({
+  userPasswordWriter: { applyNewPassword },
+}));
+
+import { userSecurityResetPasswordUpdater } from "../userSecurityResetPasswordUpdater.service";
+
+describe("userSecurityResetPasswordUpdater.confirmResetPassword", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repository.findOneBy.mockResolvedValue({ id: 42, status: "PENDING" });
+    repository.findOneByOrFail.mockResolvedValue({
+      id: 42,
+      status: "PENDING",
+      structureId: 7,
+    });
+    securityRepository.findOneByOrFail.mockResolvedValue({
+      userId: 42,
+      temporaryTokens: {
+        token: "valid-token",
+        validity: new Date(Date.now() + 60_000),
+      },
+    });
+  });
+
+  it("preserves a pending account while resetting its password", async () => {
+    await userSecurityResetPasswordUpdater.confirmResetPassword({
+      userId: 42,
+      token: "valid-token",
+      newPassword: "new-password",
+      userProfile: "structure",
+    });
+
+    expect(applyNewPassword).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: expect.objectContaining({ status: "PENDING" }),
+        activatePendingAccount: false,
+      })
+    );
+  });
+});

--- a/packages/backend/src/modules/users/services/userPasswordWriter.service.ts
+++ b/packages/backend/src/modules/users/services/userPasswordWriter.service.ts
@@ -23,9 +23,9 @@ type PasswordSubject = {
 };
 
 // One place for the "I just changed someone's password" follow-up: persist
-// the new hash, activate PENDING accounts, clear soft-lock + OTP lockout, log
-// the success and terminate the active session. Called by both the change-
-// password and the reset-password flows so they stay in sync.
+// the new hash, optionally activate PENDING accounts, clear soft-lock + OTP
+// lockout, log the success and terminate the active session. Called by both
+// the change-password and reset-password flows so they stay in sync.
 export const userPasswordWriter = {
   applyNewPassword,
 };
@@ -36,6 +36,7 @@ async function applyNewPassword({
   newPassword,
   successAction,
   sessionReason,
+  activatePendingAccount = true,
   requestContext,
 }: {
   user: PasswordSubject;
@@ -43,6 +44,7 @@ async function applyNewPassword({
   newPassword: string;
   successAction: SecurityLogAction;
   sessionReason: SessionTerminationReason;
+  activatePendingAccount?: boolean;
   requestContext?: SecurityLogRequestContext;
 }): Promise<void> {
   // `getUserRepository` only covers structure / supervisor; for usager we go
@@ -64,7 +66,12 @@ async function applyNewPassword({
 
   // BLOCKED accounts stay BLOCKED; the helpers below are no-op when the
   // status condition doesn't match.
-  await userStatusManager.activateFromPending({ userProfile, userId: user.id });
+  if (activatePendingAccount) {
+    await userStatusManager.activateFromPending({
+      userProfile,
+      userId: user.id,
+    });
+  }
   await userStatusManager.clearTemporaryBlock({ userProfile, userId: user.id });
 
   await logSecurityEventForUser(successAction, userProfile, user, {

--- a/packages/backend/src/modules/users/services/userSecurityResetPasswordUpdater.service.ts
+++ b/packages/backend/src/modules/users/services/userSecurityResetPasswordUpdater.service.ts
@@ -83,6 +83,9 @@ async function confirmResetPassword({
     newPassword,
     successAction: "RESET_PASSWORD_SUCCESS",
     sessionReason: "PASSWORD_RESET",
+    // Resetting credentials must not approve a pending account. In particular,
+    // structure administrators are activated only by the supervisor workflow.
+    activatePendingAccount: false,
     requestContext,
   });
 


### PR DESCRIPTION
### Motivation

- A password-reset confirmation flow was activating `PENDING` structure administrators, allowing unapproved tenants to obtain admin access. 
- Activation must remain under the supervisor approval workflow and not be triggered by a credential reset. 
- The change restores the intended separation between credential management and account approval to prevent privilege escalation.

### Description

- Add an optional `activatePendingAccount` parameter to `userPasswordWriter.applyNewPassword` and default it to `true` so callers can opt-out of activating `PENDING` accounts. 
- Call `applyNewPassword` from the reset-confirmation flow with `activatePendingAccount: false` to avoid changing `PENDING` -> `ACTIVE` on password reset. 
- Update function comments to clarify activation behavior and preserve existing behavior for non-reset flows. 
- Add a regression test `userSecurityResetPasswordUpdater.service.spec.ts` that verifies a structure-admin in `PENDING` remains `PENDING` after reset.

Files changed: `packages/backend/src/modules/users/services/userPasswordWriter.service.ts`, `packages/backend/src/modules/users/services/userSecurityResetPasswordUpdater.service.ts`, `packages/backend/src/modules/users/services/tests/userSecurityResetPasswordUpdater.service.spec.ts`.

### Testing

- Ran the focused unit test: `pnpm --filter @domifa/backend exec jest --runInBand --runTestsByPath src/modules/users/services/tests/userSecurityResetPasswordUpdater.service.spec.ts`, which passed. 
- Built the workspace packages: `pnpm --filter @domifa/common build && pnpm --filter @domifa/backend build`, which completed successfully. 
- Ran lint for the backend package: `pnpm --filter @domifa/backend lint`, which completed without reported failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9ed340cd20833385902ed7d6758414)